### PR TITLE
Documentation typos fixed and minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ service proxies, or anything you want as you can add your own type.
 
 The service discovery can be extended using bridges to import services from Docker, Kubernetes, Consul...
 
+You can find the [full documentation](http://vertx.io/docs/#microservices) on the Vert.x website.
+
 ## Kubernetes Discovery Bridge
 
 The `vertx-discovery-bridge-kubernetes` is a discovery bridge importing the services from Kubernetes in the Vert.x service discovery.

--- a/vertx-service-discovery-backend-redis/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-service-discovery-backend-redis/src/main/asciidoc/groovy/index.adoc
@@ -17,7 +17,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-backend-redis</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -25,7 +25,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-backend-redis:3.3.0'
+compile 'io.vertx:vertx-service-discovery-backend-redis:3.3.1-SNAPSHOT'
 ----
 
 Be aware that you can have only a single implementation of the SPI in your _classpath_. If none,

--- a/vertx-service-discovery-backend-redis/src/main/asciidoc/java/index.adoc
+++ b/vertx-service-discovery-backend-redis/src/main/asciidoc/java/index.adoc
@@ -17,7 +17,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-backend-redis</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -25,7 +25,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-backend-redis:3.3.0'
+compile 'io.vertx:vertx-service-discovery-backend-redis:3.3.1-SNAPSHOT'
 ----
 
 Be aware that you can have only a single implementation of the SPI in your _classpath_. If none,

--- a/vertx-service-discovery-backend-redis/src/main/asciidoc/js/index.adoc
+++ b/vertx-service-discovery-backend-redis/src/main/asciidoc/js/index.adoc
@@ -17,7 +17,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-backend-redis</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -25,7 +25,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-backend-redis:3.3.0'
+compile 'io.vertx:vertx-service-discovery-backend-redis:3.3.1-SNAPSHOT'
 ----
 
 Be aware that you can have only a single implementation of the SPI in your _classpath_. If none,

--- a/vertx-service-discovery-backend-redis/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-service-discovery-backend-redis/src/main/asciidoc/ruby/index.adoc
@@ -17,7 +17,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-backend-redis</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -25,7 +25,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-backend-redis:3.3.0'
+compile 'io.vertx:vertx-service-discovery-backend-redis:3.3.1-SNAPSHOT'
 ----
 
 Be aware that you can have only a single implementation of the SPI in your _classpath_. If none,

--- a/vertx-service-discovery-bridge-consul/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-service-discovery-bridge-consul/src/main/asciidoc/groovy/index.adoc
@@ -26,7 +26,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-bridge-consul</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -34,7 +34,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-bridge-consul:3.3.0'
+compile 'io.vertx:vertx-service-discovery-bridge-consul:3.3.1-SNAPSHOT'
 ----
 
 Then, when creating the service discovery registers this bridge as follows:

--- a/vertx-service-discovery-bridge-consul/src/main/asciidoc/java/index.adoc
+++ b/vertx-service-discovery-bridge-consul/src/main/asciidoc/java/index.adoc
@@ -26,7 +26,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-bridge-consul</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -34,7 +34,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-bridge-consul:3.3.0'
+compile 'io.vertx:vertx-service-discovery-bridge-consul:3.3.1-SNAPSHOT'
 ----
 
 Then, when creating the service discovery registers this bridge as follows:

--- a/vertx-service-discovery-bridge-consul/src/main/asciidoc/js/index.adoc
+++ b/vertx-service-discovery-bridge-consul/src/main/asciidoc/js/index.adoc
@@ -26,7 +26,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-bridge-consul</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -34,7 +34,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-bridge-consul:3.3.0'
+compile 'io.vertx:vertx-service-discovery-bridge-consul:3.3.1-SNAPSHOT'
 ----
 
 Then, when creating the service discovery registers this bridge as follows:

--- a/vertx-service-discovery-bridge-consul/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-service-discovery-bridge-consul/src/main/asciidoc/ruby/index.adoc
@@ -26,7 +26,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-bridge-consul</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -34,7 +34,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-bridge-consul:3.3.0'
+compile 'io.vertx:vertx-service-discovery-bridge-consul:3.3.1-SNAPSHOT'
 ----
 
 Then, when creating the service discovery registers this bridge as follows:

--- a/vertx-service-discovery-bridge-docker-links/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-service-discovery-bridge-docker-links/src/main/asciidoc/groovy/index.adoc
@@ -22,7 +22,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-bridge-docker-links</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -30,7 +30,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-bridge-docker-links:3.3.0'
+compile 'io.vertx:vertx-service-discovery-bridge-docker-links:3.3.1-SNAPSHOT'
 ----
 
 Then, when creating the service discovery, registers this bridge as follows:

--- a/vertx-service-discovery-bridge-docker-links/src/main/asciidoc/java/index.adoc
+++ b/vertx-service-discovery-bridge-docker-links/src/main/asciidoc/java/index.adoc
@@ -22,7 +22,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-bridge-docker-links</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -30,7 +30,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-bridge-docker-links:3.3.0'
+compile 'io.vertx:vertx-service-discovery-bridge-docker-links:3.3.1-SNAPSHOT'
 ----
 
 Then, when creating the service discovery, registers this bridge as follows:

--- a/vertx-service-discovery-bridge-docker-links/src/main/asciidoc/js/index.adoc
+++ b/vertx-service-discovery-bridge-docker-links/src/main/asciidoc/js/index.adoc
@@ -22,7 +22,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-bridge-docker-links</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -30,7 +30,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-bridge-docker-links:3.3.0'
+compile 'io.vertx:vertx-service-discovery-bridge-docker-links:3.3.1-SNAPSHOT'
 ----
 
 Then, when creating the service discovery, registers this bridge as follows:

--- a/vertx-service-discovery-bridge-docker-links/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-service-discovery-bridge-docker-links/src/main/asciidoc/ruby/index.adoc
@@ -22,7 +22,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-bridge-docker-links</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -30,7 +30,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-bridge-docker-links:3.3.0'
+compile 'io.vertx:vertx-service-discovery-bridge-docker-links:3.3.1-SNAPSHOT'
 ----
 
 Then, when creating the service discovery, registers this bridge as follows:

--- a/vertx-service-discovery-bridge-kubernetes/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-service-discovery-bridge-kubernetes/src/main/asciidoc/groovy/index.adoc
@@ -20,7 +20,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-bridge-kubernetes</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -28,7 +28,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-bridge-kubernetes:3.3.0'
+compile 'io.vertx:vertx-service-discovery-bridge-kubernetes:3.3.1-SNAPSHOT'
 ----
 
 == Configuring the bridge

--- a/vertx-service-discovery-bridge-kubernetes/src/main/asciidoc/java/index.adoc
+++ b/vertx-service-discovery-bridge-kubernetes/src/main/asciidoc/java/index.adoc
@@ -20,7 +20,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-bridge-kubernetes</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -28,7 +28,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-bridge-kubernetes:3.3.0'
+compile 'io.vertx:vertx-service-discovery-bridge-kubernetes:3.3.1-SNAPSHOT'
 ----
 
 == Configuring the bridge

--- a/vertx-service-discovery-bridge-kubernetes/src/main/asciidoc/js/index.adoc
+++ b/vertx-service-discovery-bridge-kubernetes/src/main/asciidoc/js/index.adoc
@@ -20,7 +20,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-bridge-kubernetes</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -28,7 +28,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-bridge-kubernetes:3.3.0'
+compile 'io.vertx:vertx-service-discovery-bridge-kubernetes:3.3.1-SNAPSHOT'
 ----
 
 == Configuring the bridge

--- a/vertx-service-discovery-bridge-kubernetes/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-service-discovery-bridge-kubernetes/src/main/asciidoc/ruby/index.adoc
@@ -20,7 +20,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-discovery-bridge-kubernetes</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -28,7 +28,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery-bridge-kubernetes:3.3.0'
+compile 'io.vertx:vertx-service-discovery-bridge-kubernetes:3.3.1-SNAPSHOT'
 ----
 
 == Configuring the bridge

--- a/vertx-service-discovery/.vertx/debug-js/vertx-js/counter.js
+++ b/vertx-service-discovery/.vertx/debug-js/vertx-js/counter.js
@@ -44,7 +44,7 @@ var Counter = function(j_val) {
     if (__args.length === 1 && typeof __args[0] === 'function') {
       j_counter["get(io.vertx.core.Handler)"](function(ar) {
       if (ar.succeeded()) {
-        resultHandler(ar.result(), null);
+        resultHandler(utils.convReturnLong(ar.result()), null);
       } else {
         resultHandler(null, ar.cause());
       }
@@ -63,7 +63,7 @@ var Counter = function(j_val) {
     if (__args.length === 1 && typeof __args[0] === 'function') {
       j_counter["incrementAndGet(io.vertx.core.Handler)"](function(ar) {
       if (ar.succeeded()) {
-        resultHandler(ar.result(), null);
+        resultHandler(utils.convReturnLong(ar.result()), null);
       } else {
         resultHandler(null, ar.cause());
       }
@@ -82,7 +82,7 @@ var Counter = function(j_val) {
     if (__args.length === 1 && typeof __args[0] === 'function') {
       j_counter["getAndIncrement(io.vertx.core.Handler)"](function(ar) {
       if (ar.succeeded()) {
-        resultHandler(ar.result(), null);
+        resultHandler(utils.convReturnLong(ar.result()), null);
       } else {
         resultHandler(null, ar.cause());
       }
@@ -101,7 +101,7 @@ var Counter = function(j_val) {
     if (__args.length === 1 && typeof __args[0] === 'function') {
       j_counter["decrementAndGet(io.vertx.core.Handler)"](function(ar) {
       if (ar.succeeded()) {
-        resultHandler(ar.result(), null);
+        resultHandler(utils.convReturnLong(ar.result()), null);
       } else {
         resultHandler(null, ar.cause());
       }
@@ -121,7 +121,7 @@ var Counter = function(j_val) {
     if (__args.length === 2 && typeof __args[0] ==='number' && typeof __args[1] === 'function') {
       j_counter["addAndGet(long,io.vertx.core.Handler)"](value, function(ar) {
       if (ar.succeeded()) {
-        resultHandler(ar.result(), null);
+        resultHandler(utils.convReturnLong(ar.result()), null);
       } else {
         resultHandler(null, ar.cause());
       }
@@ -141,7 +141,7 @@ var Counter = function(j_val) {
     if (__args.length === 2 && typeof __args[0] ==='number' && typeof __args[1] === 'function') {
       j_counter["getAndAdd(long,io.vertx.core.Handler)"](value, function(ar) {
       if (ar.succeeded()) {
-        resultHandler(ar.result(), null);
+        resultHandler(utils.convReturnLong(ar.result()), null);
       } else {
         resultHandler(null, ar.cause());
       }

--- a/vertx-service-discovery/.vertx/debug-js/vertx-js/http_connection.js
+++ b/vertx-service-discovery/.vertx/debug-js/vertx-js/http_connection.js
@@ -37,6 +37,39 @@ var HttpConnection = function(j_val) {
   var that = this;
 
   /**
+   @return the current connection window size or <code>-1</code> for HTTP/1.x
+
+   @public
+
+   @return {number}
+   */
+  this.getWindowSize = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return j_httpConnection["getWindowSize()"]();
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+   Update the current connection wide window size to a new size.
+   <p/>
+   Increasing this value, gives better performance when several data streams are multiplexed
+   <p/>
+   This is not implemented for HTTP/1.x.
+
+   @public
+   @param windowSize {number} the new window size 
+   @return {HttpConnection} a reference to this, so the API can be used fluently
+   */
+  this.setWindowSize = function(windowSize) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] ==='number') {
+      j_httpConnection["setWindowSize(int)"](windowSize);
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
    Send a go away frame to the remote endpoint of the connection.
    <p/>
    <ul>

--- a/vertx-service-discovery/.vertx/debug-js/vertx-js/timeout_stream.js
+++ b/vertx-service-discovery/.vertx/debug-js/vertx-js/timeout_stream.js
@@ -58,7 +58,7 @@ var TimeoutStream = function(j_val) {
     var __args = arguments;
     if (__args.length === 1 && (typeof __args[0] === 'function' || __args[0] == null)) {
       j_timeoutStream["handler(io.vertx.core.Handler)"](handler == null ? null : function(jVal) {
-      handler(jVal);
+      handler(utils.convReturnLong(jVal));
     });
       return that;
     } else throw new TypeError('function invoked with invalid arguments');

--- a/vertx-service-discovery/.vertx/debug-js/vertx-js/util/utils.js
+++ b/vertx-service-discovery/.vertx/debug-js/vertx-js/util/utils.js
@@ -2,6 +2,7 @@ var JsonObject = Packages.io.vertx.core.json.JsonObject;
 var JsonArray = Packages.io.vertx.core.json.JsonArray;
 var asList = java.util.Arrays.asList;
 var Character = Java.type("java.lang.Character");
+var Long = Java.type("java.lang.Long");
 var LongArrayType = Java.type("java.lang.Long[]");
 var ShortArrayType = Java.type("java.lang.Short[]");
 var ByteArrayType = Java.type("java.lang.Byte[]");
@@ -256,6 +257,8 @@ utils.convParamSetEnum = function(arr, constructor) {
 utils.convReturnTypeUnknown = function(ret) {
   if (ret instanceof JsonObject || ret instanceof JsonArray) {
     return JSON.parse(ret.encode());
+  } else if (ret instanceof Long) {
+    return ret.doubleValue();
   } else {
     return ret;
   }
@@ -272,6 +275,11 @@ utils.convReturnThrowable = function(ret) {
 // Convert a Java JsonObject/JsonArray return to JS JSON
 utils.convReturnJson = function(param) {
   return param != null ? JSON.parse(param.encode()) : null;
+};
+
+// Convert a java.lang.Long return to JS number
+utils.convReturnLong = function(param) {
+  return param != null ? param.doubleValue() : null;
 };
 
 /*
@@ -376,6 +384,23 @@ utils.convReturnListSetEnum = function(jList) {
     while (iter.hasNext()) {
       var elem = iter.next();
       arr[pos++] = elem != null ? elem.toString() : null;
+    }
+    return arr;
+  } else {
+    return null;
+  }
+};
+
+// Convert a list/set containing Long return
+utils.convReturnListSetLong = function(jList) {
+  if (jList) {
+    var arr = [];
+    arr.length = jList.size();
+    var iter = jList.iterator();
+    var pos = 0;
+    while (iter.hasNext()) {
+      var elem = iter.next();
+      arr[pos++] = elem != null ? elem.doubleValue() : null;
     }
     return arr;
   } else {

--- a/vertx-service-discovery/.vertx/debug-js/vertx-js/vertx.js
+++ b/vertx-service-discovery/.vertx/debug-js/vertx-js/vertx.js
@@ -255,7 +255,7 @@ var Vertx = function(j_val) {
     var __args = arguments;
     if (__args.length === 2 && typeof __args[0] ==='number' && typeof __args[1] === 'function') {
       return j_vertx["setTimer(long,io.vertx.core.Handler)"](delay, function(jVal) {
-      handler(jVal);
+      handler(utils.convReturnLong(jVal));
     });
     } else throw new TypeError('function invoked with invalid arguments');
   };
@@ -288,7 +288,7 @@ var Vertx = function(j_val) {
     var __args = arguments;
     if (__args.length === 2 && typeof __args[0] ==='number' && typeof __args[1] === 'function') {
       return j_vertx["setPeriodic(long,io.vertx.core.Handler)"](delay, function(jVal) {
-      handler(jVal);
+      handler(utils.convReturnLong(jVal));
     });
     } else throw new TypeError('function invoked with invalid arguments');
   };

--- a/vertx-service-discovery/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-service-discovery/src/main/asciidoc/groovy/index.adoc
@@ -9,7 +9,7 @@ service proxy, a HTTP endpoint and any other resource you can imagine as soon as
 with it. It does not have to be a vert.x entity, but can be anything. Each service is described by a
 `link:../dataobjects.html#Record[Record]`.
 
-The service discovery implements the interactions defined in the service-oriented computing. And to some extend,
+The service discovery implements the interactions defined in service-oriented computing. And to some extend,
 also provides the dynamic service-oriented computing interactions. So, applications can react to arrival and
 departure of services.
 
@@ -21,20 +21,20 @@ A service provider can:
 
 A service consumer can:
 
-* lookup for services
+* lookup services
 * bind to a selected service (it gets a `link:../../groovydoc/io/vertx/groovy/servicediscovery/ServiceReference.html[ServiceReference]`) and use it
 * release the service once the consumer is done with it
 * listen for arrival, departure and modification of services.
 
-Consumer would 1) lookup for service record matching their need, 2) retrieve the
+Consumer would 1) lookup a service record matching their need, 2) retrieve the
 `link:../../groovydoc/io/vertx/groovy/servicediscovery/ServiceReference.html[ServiceReference]` that give access to the service, 3) get a service object to access
 the service, 4) release the service object once done.
 
-A state above, the central piece of information shared by the providers and consumers are
+As stated above, the central piece of information shared by the providers and consumers are
 `link:../dataobjects.html#Record[records]`.
 
 Providers and consumers must create their own `link:../../groovydoc/io/vertx/groovy/servicediscovery/ServiceDiscovery.html[ServiceDiscovery]` instance. These
-instances are collaborating in background (distributed structure) to keep the set of services in sync.
+instances are collaborating in the background (distributed structure) to keep the set of services in sync.
 
 The service discovery supports bridges to import and export services from / to other discovery technologies.
 
@@ -50,7 +50,7 @@ descriptor:
 <dependency>
 <groupId>io.vertx</groupId>
 <artifactId>vertx-service-discovery</artifactId>
-<version>3.3.0</version>
+<version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -58,7 +58,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery:3.3.0'
+compile 'io.vertx:vertx-service-discovery:3.3.1-SNAPSHOT'
 ----
 
 == Overall concepts
@@ -69,9 +69,9 @@ The discovery mechanism is based on a few concepts explained in this section.
 
 A service `link:../dataobjects.html#Record[Record]` is an object that describes a service published by a service
 provider. It contains a name, some metadata, a location object (describing where is the service). This record is
-the only objects shared by the provider (having published it) and the consumer (retrieve it when doing a lookup).
+the only object shared by the provider (having published it) and the consumer (retrieve it when doing a lookup).
 
-The metadata and even the location format depends on the `service type` (see below).
+The metadata and even the location format depend on the `service type` (see below).
 
 A record is published when the provider is ready to be used, and withdrawn when the service provider is stopping.
 
@@ -91,12 +91,12 @@ It is important to release service references to cleanup the objects and update 
 
 === Service object
 
-The service object is the object that give access to a service. It has various form, such as a proxy, a client, or
-may even be non existent for some service type. The nature of the service object depends of the service type.
+The service object is the object that gives access to a service. It can come in various forms, such as a proxy, a client,
+and may even be non-existent for some service types. The nature of the service object depends on the service type.
 
 === Service types
 
-Services are resources, and it exists a wide variety of resources. They can be functional services, databases,
+Services are just resources, and they exist in wide variety. They can be functional services, databases,
 REST APIs, and so on. The Vert.x service discovery has the concept of service types to handle this heterogeneity.
 Each type defines:
 
@@ -231,20 +231,20 @@ the matching ones. In the first case, the first matching record is returned.
 Consumer can pass a filter to select the service. There are two ways to describe the filter:
 
 1. A function taking a `link:../dataobjects.html#Record[Record]` as parameter and returning a boolean
-2. This filter is a JSON object. Each entry of the given filter are checked against the record. All entry must
-match exactly the record. The entry can use the special `*` value to denotes a requirement on the key, but not on
+2. This filter is a JSON object. Each entry of the given filter is checked against the record. All entries must
+exactly match the record. The entry can use the special `*` value to denote a requirement on the key, but not on
 the value.
 
-Let's take some example of JSON filter:
+Let's see an example of a JSON filter:
 ----
-{ "name" = "a" } => matches records with name set fo "a"
+{ "name" = "a" } => matches records with name set to "a"
 { "color" = "*" } => matches records with "color" set
 { "color" = "red" } => only matches records with "color" set to "red"
 { "color" = "red", "name" = "a"} => only matches records with name set to "a", and color set to "red"
 ----
 
 If the JSON filter is not set (`null` or empty), it accepts all records. When using functions, to accept all
-records, you must return true regardless the record.
+records, you must return _true_ regardless the record.
 
 Here are some examples:
 
@@ -337,9 +337,9 @@ discovery.getRecords([
 
 ----
 
-You can retrieve a single record or all matching record with
+You can retrieve a single record or all matching records with
 `link:../../groovydoc/io/vertx/groovy/servicediscovery/ServiceDiscovery.html#getRecords(io.vertx.core.json.JsonObject,%20io.vertx.core.Handler)[getRecords]`.
-By default, record lookup does includes only records with a `status` set to `UP`. This can be overridden:
+By default, record lookup does include only records with a `status` set to `UP`. This can be overridden:
 
 * when using JSON filter, just set `status` to the value you want (or `*` to accept all status)
 * when using function, set the `includeOutOfService` parameter to `true` in
@@ -371,8 +371,8 @@ Don't forget to release the reference once done.
 The service reference represents a binding with the service provider.
 
 When retrieving a service reference you can pass a `JsonObject` used to configure the
-service object. It can contains various data about the service objects. Some service types do not needs additional
-configuration, some requires configuration (as data sources):
+service object. It can contain various data about the service object. Some service types do not needs additional
+configuration, some require configuration (as data sources):
 
 [source,groovy]
 ----
@@ -394,19 +394,19 @@ reference.release()
 A said above, the service discovery has the service type concept to manage the heterogeneity of the
 different services.
 
-Are provided by default:
+These types are provided by default:
 
-* `link:../../groovydoc/io/vertx/groovy/servicediscovery/types/HttpEndpoint.html[HttpEndpoint]` - for REST API, the service object is a
+* `link:../../groovydoc/io/vertx/groovy/servicediscovery/types/HttpEndpoint.html[HttpEndpoint]` - for REST API's, the service object is a
 `link:../../groovydoc/io/vertx/groovy/core/http/HttpClient.html[HttpClient]` configured on the host and port (the location is the url).
 * `link:../../groovydoc/io/vertx/groovy/servicediscovery/types/EventBusService.html[EventBusService]` - for service proxies, the service object is a proxy. Its
 type is the proxies interface (the location is the address).
-* `link:../../groovydoc/io/vertx/groovy/servicediscovery/types/MessageSource.html[MessageSource]` - for message source (publisher), the service object is a
+* `link:../../groovydoc/io/vertx/groovy/servicediscovery/types/MessageSource.html[MessageSource]` - for message sources (publisher), the service object is a
 `link:../../groovydoc/io/vertx/groovy/core/eventbus/MessageConsumer.html[MessageConsumer]` (the location is the address).
 * `link:../../groovydoc/io/vertx/groovy/servicediscovery/types/JDBCDataSource.html[JDBCDataSource]` - for JDBC data sources, the service object is a
 `link:../../groovydoc/io/vertx/groovy/ext/jdbc/JDBCClient.html[JDBCClient]` (the configuration of the client is computed from the location, metadata and
 consumer configuration).
 
-This section gives details about service types and describes how can be used the default service types.
+This section gives details about service types in general and describes how to use the default service types.
 
 === Services with no type
 
@@ -428,7 +428,7 @@ objects are `link:../../groovydoc/io/vertx/groovy/core/http/HttpClient.html[Http
 To publish a HTTP endpoint, you need a `link:../dataobjects.html#Record[Record]`. You can create the record using
 `link:../../groovydoc/io/vertx/groovy/servicediscovery/types/HttpEndpoint.html#createRecord(java.lang.String,%20java.lang.String,%20int,%20java.lang.String,%20io.vertx.core.json.JsonObject)[HttpEndpoint.createRecord]`.
 
-The next snippet illustrates hot to create `link:../dataobjects.html#Record[Record]` from
+The next snippet illustrates hot to create a `link:../dataobjects.html#Record[Record]` from
 `link:../../groovydoc/io/vertx/groovy/servicediscovery/types/HttpEndpoint.html[HttpEndpoint]`:
 
 [source, groovy]
@@ -447,7 +447,7 @@ def record2 = HttpEndpoint.createRecord("some-other-name", true, "localhost", 84
 
 ----
 
-When you run your service in a container or on the cloud, it may not knows its public IP and public port, so the
+When you run your service in a container or on the cloud, it may not know its public IP and public port, so the
 publication must be done by another entity having this info. Generally it's a bridge.
 
 ==== Consuming a HTTP endpoint
@@ -511,12 +511,12 @@ HttpEndpoint.getClient(discovery, [
 
 In this second version, the service object is released using
 `link:../../groovydoc/io/vertx/groovy/servicediscovery/ServiceDiscovery.html#releaseServiceObject(io.vertx.servicediscovery.ServiceDiscovery,%20java.lang.Object)[ServiceDiscovery.releaseServiceObject]`,
-as you don't hold the service reference.
+so you no longer hold on to the service reference.
 
 === Event bus services
 
-Event bus services are service proxies. They implement async-RPC services on top of the event bus. When retrieved
-a service object from an event bus service, you get a service proxy in the right type. You can access helper
+Event bus services are service proxies. They implement async-RPC services on top of the event bus. When retrieving
+a service object from an event bus service, you get a service proxy of the right type. You can access helper
 methods from `link:../../groovydoc/io/vertx/groovy/servicediscovery/types/EventBusService.html[EventBusService]`.
 
 Notice that service proxies (service implementations and service interfaces) are developed in Java.
@@ -545,7 +545,7 @@ discovery.publish(record, { ar ->
 To consume an event bus service you can either retrieve the record and then get the reference, or use the
 `link:../../groovydoc/io/vertx/groovy/servicediscovery/types/EventBusService.html[EventBusService]` interface that combines the two operations in one call.
 
-However, as the service is search by (Java) interface, you need to specify the type of client you expect.
+However, as the service is searched by (Java) interface, you need to specify the type of client you expect.
 
 [source, groovy]
 ----
@@ -566,14 +566,14 @@ ServiceDiscovery.releaseServiceObject(discovery, svc);
 
 === Message source
 
-A message source is a component sending message on the event bus on a specific address. Message source clients are
+A message source is a component sending messages on the event bus on a specific address. Message source clients are
 `link:../../groovydoc/io/vertx/groovy/core/eventbus/MessageConsumer.html[MessageConsumer]`.
 
 The _location_ or a message source service is the event bus address on which messages are sent.
 
 ==== Publishing a message source
 
-As for the other service types, publishing a message source is a 2-steps process:
+As for the other service types, publishing a message source is a 2-step process:
 
 1. create a record, using `link:../../groovydoc/io/vertx/groovy/servicediscovery/types/MessageSource.html[MessageSource]`
 2. publish the record
@@ -657,12 +657,12 @@ MessageSource.getConsumer(discovery, [
 
 === JDBC Data source
 
-Data sources represents databases or data stores. JDBC data sources are a specialization for database accessible
+Data sources represents databases or data stores. JDBC data sources are a specialization for databases accessible
 using a JDBC driver. The client of a JDBC data source service is a `link:../../groovydoc/io/vertx/groovy/ext/jdbc/JDBCClient.html[JDBCClient]`.
 
 === Publishing a JDBC service
 
-As for the other service types, publishing a message source is a 2-steps process:
+As for the other service types, publishing a message source is a 2-step process:
 
 1. create a record, using `link:../../groovydoc/io/vertx/groovy/servicediscovery/types/JDBCDataSource.html[JDBCDataSource]`
 2. publish the record
@@ -684,13 +684,13 @@ discovery.publish(record, { ar ->
 
 As JDBC data sources can represent a high variety of databases, and their access is often different, the record is
 rather unstructured. The `location` is a simple JSON object that should provide the fields to access the data
-source (JDBC url, username...). The set of field may depends on the database but also on the connection pool use
+source (JDBC url, username...). The set of fields may depend on the database but also on the connection pool used
 in front.
 
 === Consuming a JDBC service
 
-As state in the previous section, accessible data source depends on the data source itself. To build the
-`link:../../groovydoc/io/vertx/groovy/ext/jdbc/JDBCClient.html[JDBCClient]`, are merged: the record location, the metadata and a json object provided by
+As stated in the previous section, how to access a data source depends on the data source itself. To build the
+`link:../../groovydoc/io/vertx/groovy/ext/jdbc/JDBCClient.html[JDBCClient]`, you can merge configuration: the record location, the metadata and a json object provided by
 the consumer:
 
 [source, groovy]
@@ -718,7 +718,7 @@ discovery.getRecord([
 
 ----
 
-You can also use the `link:../../groovydoc/io/vertx/groovy/ext/jdbc/JDBCClient.html[JDBCClient]` class to to the lookup and retrieval in one call:
+You can also use the `link:../../groovydoc/io/vertx/groovy/ext/jdbc/JDBCClient.html[JDBCClient]` class to the lookup and retrieval in one call:
 
 [source, groovy]
 ----
@@ -757,7 +757,7 @@ The received record has a `status` field indicating the new state of the record:
 == Listening for service usage
 
 Every time a service reference is retrieved (`bind`) or released (`release`), an event is published on the _vertx
-.discovery.usage` address. This address is configurable from the `link:../dataobjects.html#ServiceDiscoveryOptions[ServiceDiscoveryOptions]`.
+.discovery.usage_ address. This address is configurable from the `link:../dataobjects.html#ServiceDiscoveryOptions[ServiceDiscoveryOptions]`.
 
 It lets you listen for service usage and map the service bindings.
 
@@ -776,7 +776,7 @@ You can disable the service usage support by setting the usage address to `null`
 
 == Service discovery bridges
 
-Bridges let import and export services from / to other discovery mechanism such as Docker, Kubernates, Consul...
+Bridges let you import and export services from / to other discovery mechanism such as Docker, Kubernates, Consul...
 Each bridge decides how the services are imported and exported. It does not have to be bi-directional.
 
 You can provide your own bridge by implementing the `link:../../groovydoc/io/vertx/groovy/servicediscovery/spi/ServiceImporter.html[ServiceImporter]` interface and
@@ -790,7 +790,7 @@ When the bridge is registered the
 {@link io.vertx.servicediscovery.spi.ServiceImporter#start)}
 method is called. It lets you configure the bridge. When the bridge is configured, ready and has imported /
 exported the initial services, it must complete the given `link:../../groovydoc/io/vertx/groovy/core/Future.html[Future]`. If the bridge starts
-method is blocking, it must uses an
+method is blocking, it must use an
 `link:../../groovydoc/io/vertx/groovy/core/Vertx.html#executeBlocking(io.vertx.core.Handler,%20boolean,%20io.vertx.core.Handler)[executeBlocking]` construct, and
 complete the given future object.
 

--- a/vertx-service-discovery/src/main/asciidoc/java/index.adoc
+++ b/vertx-service-discovery/src/main/asciidoc/java/index.adoc
@@ -9,7 +9,7 @@ service proxy, a HTTP endpoint and any other resource you can imagine as soon as
 with it. It does not have to be a vert.x entity, but can be anything. Each service is described by a
 `link:../../apidocs/io/vertx/servicediscovery/Record.html[Record]`.
 
-The service discovery implements the interactions defined in the service-oriented computing. And to some extend,
+The service discovery implements the interactions defined in service-oriented computing. And to some extend,
 also provides the dynamic service-oriented computing interactions. So, applications can react to arrival and
 departure of services.
 
@@ -21,20 +21,20 @@ A service provider can:
 
 A service consumer can:
 
-* lookup for services
+* lookup services
 * bind to a selected service (it gets a `link:../../apidocs/io/vertx/servicediscovery/ServiceReference.html[ServiceReference]`) and use it
 * release the service once the consumer is done with it
 * listen for arrival, departure and modification of services.
 
-Consumer would 1) lookup for service record matching their need, 2) retrieve the
+Consumer would 1) lookup a service record matching their need, 2) retrieve the
 `link:../../apidocs/io/vertx/servicediscovery/ServiceReference.html[ServiceReference]` that give access to the service, 3) get a service object to access
 the service, 4) release the service object once done.
 
-A state above, the central piece of information shared by the providers and consumers are
+As stated above, the central piece of information shared by the providers and consumers are
 `link:../../apidocs/io/vertx/servicediscovery/Record.html[records]`.
 
 Providers and consumers must create their own `link:../../apidocs/io/vertx/servicediscovery/ServiceDiscovery.html[ServiceDiscovery]` instance. These
-instances are collaborating in background (distributed structure) to keep the set of services in sync.
+instances are collaborating in the background (distributed structure) to keep the set of services in sync.
 
 The service discovery supports bridges to import and export services from / to other discovery technologies.
 
@@ -50,7 +50,7 @@ descriptor:
 <dependency>
 <groupId>io.vertx</groupId>
 <artifactId>vertx-service-discovery</artifactId>
-<version>3.3.0</version>
+<version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -58,7 +58,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery:3.3.0'
+compile 'io.vertx:vertx-service-discovery:3.3.1-SNAPSHOT'
 ----
 
 == Overall concepts
@@ -69,9 +69,9 @@ The discovery mechanism is based on a few concepts explained in this section.
 
 A service `link:../../apidocs/io/vertx/servicediscovery/Record.html[Record]` is an object that describes a service published by a service
 provider. It contains a name, some metadata, a location object (describing where is the service). This record is
-the only objects shared by the provider (having published it) and the consumer (retrieve it when doing a lookup).
+the only object shared by the provider (having published it) and the consumer (retrieve it when doing a lookup).
 
-The metadata and even the location format depends on the `service type` (see below).
+The metadata and even the location format depend on the `service type` (see below).
 
 A record is published when the provider is ready to be used, and withdrawn when the service provider is stopping.
 
@@ -91,12 +91,12 @@ It is important to release service references to cleanup the objects and update 
 
 === Service object
 
-The service object is the object that give access to a service. It has various form, such as a proxy, a client, or
-may even be non existent for some service type. The nature of the service object depends of the service type.
+The service object is the object that gives access to a service. It can come in various forms, such as a proxy, a client,
+and may even be non-existent for some service types. The nature of the service object depends on the service type.
 
 === Service types
 
-Services are resources, and it exists a wide variety of resources. They can be functional services, databases,
+Services are just resources, and they exist in wide variety. They can be functional services, databases,
 REST APIs, and so on. The Vert.x service discovery has the concept of service types to handle this heterogeneity.
 Each type defines:
 
@@ -218,20 +218,20 @@ the matching ones. In the first case, the first matching record is returned.
 Consumer can pass a filter to select the service. There are two ways to describe the filter:
 
 1. A function taking a `link:../../apidocs/io/vertx/servicediscovery/Record.html[Record]` as parameter and returning a boolean
-2. This filter is a JSON object. Each entry of the given filter are checked against the record. All entry must
-match exactly the record. The entry can use the special `*` value to denotes a requirement on the key, but not on
+2. This filter is a JSON object. Each entry of the given filter is checked against the record. All entries must
+exactly match the record. The entry can use the special `*` value to denote a requirement on the key, but not on
 the value.
 
-Let's take some example of JSON filter:
+Let's see an example of a JSON filter:
 ----
-{ "name" = "a" } => matches records with name set fo "a"
+{ "name" = "a" } => matches records with name set to "a"
 { "color" = "*" } => matches records with "color" set
 { "color" = "red" } => only matches records with "color" set to "red"
 { "color" = "red", "name" = "a"} => only matches records with name set to "a", and color set to "red"
 ----
 
 If the JSON filter is not set (`null` or empty), it accepts all records. When using functions, to accept all
-records, you must return true regardless the record.
+records, you must return _true_ regardless the record.
 
 Here are some examples:
 
@@ -310,9 +310,9 @@ discovery.getRecords(new JsonObject().put("some-label", "some-value"), ar -> {
 });
 ----
 
-You can retrieve a single record or all matching record with
+You can retrieve a single record or all matching records with
 `link:../../apidocs/io/vertx/servicediscovery/ServiceDiscovery.html#getRecords-io.vertx.core.json.JsonObject-io.vertx.core.Handler-[getRecords]`.
-By default, record lookup does includes only records with a `status` set to `UP`. This can be overridden:
+By default, record lookup does include only records with a `status` set to `UP`. This can be overridden:
 
 * when using JSON filter, just set `status` to the value you want (or `*` to accept all status)
 * when using function, set the `includeOutOfService` parameter to `true` in
@@ -343,8 +343,8 @@ Don't forget to release the reference once done.
 The service reference represents a binding with the service provider.
 
 When retrieving a service reference you can pass a `link:../../apidocs/io/vertx/core/json/JsonObject.html[JsonObject]` used to configure the
-service object. It can contains various data about the service objects. Some service types do not needs additional
-configuration, some requires configuration (as data sources):
+service object. It can contain various data about the service object. Some service types do not needs additional
+configuration, some require configuration (as data sources):
 
 [source,java]
 ----
@@ -365,19 +365,19 @@ reference.release();
 A said above, the service discovery has the service type concept to manage the heterogeneity of the
 different services.
 
-Are provided by default:
+These types are provided by default:
 
-* `link:../../apidocs/io/vertx/servicediscovery/types/HttpEndpoint.html[HttpEndpoint]` - for REST API, the service object is a
+* `link:../../apidocs/io/vertx/servicediscovery/types/HttpEndpoint.html[HttpEndpoint]` - for REST API's, the service object is a
 `link:../../apidocs/io/vertx/core/http/HttpClient.html[HttpClient]` configured on the host and port (the location is the url).
 * `link:../../apidocs/io/vertx/servicediscovery/types/EventBusService.html[EventBusService]` - for service proxies, the service object is a proxy. Its
 type is the proxies interface (the location is the address).
-* `link:../../apidocs/io/vertx/servicediscovery/types/MessageSource.html[MessageSource]` - for message source (publisher), the service object is a
+* `link:../../apidocs/io/vertx/servicediscovery/types/MessageSource.html[MessageSource]` - for message sources (publisher), the service object is a
 `link:../../apidocs/io/vertx/core/eventbus/MessageConsumer.html[MessageConsumer]` (the location is the address).
 * `link:../../apidocs/io/vertx/servicediscovery/types/JDBCDataSource.html[JDBCDataSource]` - for JDBC data sources, the service object is a
 `link:../../apidocs/io/vertx/ext/jdbc/JDBCClient.html[JDBCClient]` (the configuration of the client is computed from the location, metadata and
 consumer configuration).
 
-This section gives details about service types and describes how can be used the default service types.
+This section gives details about service types in general and describes how to use the default service types.
 
 === Services with no type
 
@@ -394,20 +394,20 @@ You can create your own service type by implementing the `link:../../apidocs/io/
 1. (optional) Create a public interface extending `link:../../apidocs/io/vertx/servicediscovery/spi/ServiceType.html[ServiceType]`. This interface is
 only used to provide helper methods to ease the usage of your type such as `createRecord` methods, `getX` where `X`
 is the type of service object you retrieve and so on. Check `link:../../apidocs/io/vertx/servicediscovery/types/HttpEndpoint.html[HttpEndpoint]` or
-`link:../../apidocs/io/vertx/servicediscovery/types/MessageSource.html[MessageSource]` for examples
-2. Create a class implementing `link:../../apidocs/io/vertx/servicediscovery/spi/ServiceType.html[ServiceType]` or the interface you created in the
+`link:../../apidocs/io/vertx/servicediscovery/types/MessageSource.html[MessageSource]` for example
+2. Create a class implementing `link:../../apidocs/io/vertx/servicediscovery/spi/ServiceType.html[ServiceType]` or the interface you created in
 step 1. The type has a `name`, and a method to create the `link:../../apidocs/io/vertx/servicediscovery/ServiceReference.html[ServiceReference]` for this
 type. The name must match the `type` field of the `link:../../apidocs/io/vertx/servicediscovery/Record.html[Record]` associated with your type.
-3. Create a class extending `io.vertx.ext.discovery.types.AbstractServiceReference`. You can parameterized
+3. Create a class extending `io.vertx.ext.discovery.types.AbstractServiceReference`. You can parameterize
 the class with the type of service object your are going to return. You must implement
-`AbstractServiceReference#retrieve()` that create the service object. This
+`AbstractServiceReference#retrieve()` that creates the service object. This
 method is only called once. If your service object needs cleanup, also override
 `AbstractServiceReference#close()`.
 4. Create a `META-INF/services/io.vertx.ext.discovery.spi.ServiceType` file that is packaged in your jar. In this
 file, just indicate the fully qualified name of the class created at step 2.
 5. Creates a jar containing the service type interface (step 1), the implementation (step 2 and 3) and the
 service descriptor file (step 4). Put this jar in the classpath of your application. Here you go, your service
-type is available.
+type is now available.
 
 
 === HTTP endpoints
@@ -420,7 +420,7 @@ objects are `link:../../apidocs/io/vertx/core/http/HttpClient.html[HttpClient]` 
 To publish a HTTP endpoint, you need a `link:../../apidocs/io/vertx/servicediscovery/Record.html[Record]`. You can create the record using
 `link:../../apidocs/io/vertx/servicediscovery/types/HttpEndpoint.html#createRecord-java.lang.String-java.lang.String-int-java.lang.String-io.vertx.core.json.JsonObject-[HttpEndpoint.createRecord]`.
 
-The next snippet illustrates hot to create `link:../../apidocs/io/vertx/servicediscovery/Record.html[Record]` from
+The next snippet illustrates hot to create a `link:../../apidocs/io/vertx/servicediscovery/Record.html[Record]` from
 `link:../../apidocs/io/vertx/servicediscovery/types/HttpEndpoint.html[HttpEndpoint]`:
 
 [source, java]
@@ -446,7 +446,7 @@ Record record2 = HttpEndpoint.createRecord(
 );
 ----
 
-When you run your service in a container or on the cloud, it may not knows its public IP and public port, so the
+When you run your service in a container or on the cloud, it may not know its public IP and public port, so the
 publication must be done by another entity having this info. Generally it's a bridge.
 
 ==== Consuming a HTTP endpoint
@@ -501,12 +501,12 @@ HttpEndpoint.getClient(discovery, new JsonObject().put("name", "some-http-servic
 
 In this second version, the service object is released using
 `link:../../apidocs/io/vertx/servicediscovery/ServiceDiscovery.html#releaseServiceObject-io.vertx.servicediscovery.ServiceDiscovery-java.lang.Object-[ServiceDiscovery.releaseServiceObject]`,
-as you don't hold the service reference.
+so you no longer hold on to the service reference.
 
 === Event bus services
 
-Event bus services are service proxies. They implement async-RPC services on top of the event bus. When retrieved
-a service object from an event bus service, you get a service proxy in the right type. You can access helper
+Event bus services are service proxies. They implement async-RPC services on top of the event bus. When retrieving
+a service object from an event bus service, you get a service proxy of the right type. You can access helper
 methods from `link:../../apidocs/io/vertx/servicediscovery/types/EventBusService.html[EventBusService]`.
 
 Notice that service proxies (service implementations and service interfaces) are developed in Java.
@@ -530,7 +530,7 @@ discovery.publish(record, ar -> {
 });
 ----
 
-You can also pass the service interface as class too:
+You can also pass the service interface as class:
 
 [source, java]
 ----
@@ -548,9 +548,9 @@ discovery.publish(record, ar -> {
 
 ==== Consuming an event bus service
 To consume an event bus service you can either retrieve the record and then get the reference, or use the
-`link:../../apidocs/io/vertx/servicediscovery/types/EventBusService.html[EventBusService]` interface that combine the two operations in one call.
+`link:../../apidocs/io/vertx/servicediscovery/types/EventBusService.html[EventBusService]` interface that combines the two operations in one call.
 
-When using the reference, you would do somehting like:
+When using the reference, you would do something like:
 [source, java]
 ----
 discovery.getRecord(new JsonObject().put("name", "some-eventbus-service"), ar -> {
@@ -584,14 +584,14 @@ ServiceDiscovery.releaseServiceObject(discovery, service);
 
 === Message source
 
-A message source is a component sending message on the event bus on a specific address. Message source clients are
+A message source is a component sending messages on the event bus on a specific address. Message source clients are
 `link:../../apidocs/io/vertx/core/eventbus/MessageConsumer.html[MessageConsumer]`.
 
 The _location_ or a message source service is the event bus address on which messages are sent.
 
 ==== Publishing a message source
 
-As for the other service types, publishing a message source is a 2-steps process:
+As for the other service types, publishing a message source is a 2-step process:
 
 1. create a record, using `link:../../apidocs/io/vertx/servicediscovery/types/MessageSource.html[MessageSource]`
 2. publish the record
@@ -688,12 +688,12 @@ MessageSource.<JsonObject>getConsumer(discovery, new JsonObject().put("name", "s
 
 === JDBC Data source
 
-Data sources represents databases or data stores. JDBC data sources are a specialization for database accessible
+Data sources represents databases or data stores. JDBC data sources are a specialization for databases accessible
 using a JDBC driver. The client of a JDBC data source service is a `link:../../apidocs/io/vertx/ext/jdbc/JDBCClient.html[JDBCClient]`.
 
 === Publishing a JDBC service
 
-As for the other service types, publishing a message source is a 2-steps process:
+As for the other service types, publishing a message source is a 2-step process:
 
 1. create a record, using `link:../../apidocs/io/vertx/servicediscovery/types/JDBCDataSource.html[JDBCDataSource]`
 2. publish the record
@@ -713,13 +713,13 @@ discovery.publish(record, ar -> {
 
 As JDBC data sources can represent a high variety of databases, and their access is often different, the record is
 rather unstructured. The `location` is a simple JSON object that should provide the fields to access the data
-source (JDBC url, username...). The set of field may depends on the database but also on the connection pool use
+source (JDBC url, username...). The set of fields may depend on the database but also on the connection pool used
 in front.
 
 === Consuming a JDBC service
 
-As state in the previous section, accessible data source depends on the data source itself. To build the
-`link:../../apidocs/io/vertx/ext/jdbc/JDBCClient.html[JDBCClient]`, are merged: the record location, the metadata and a json object provided by
+As stated in the previous section, how to access a data source depends on the data source itself. To build the
+`link:../../apidocs/io/vertx/ext/jdbc/JDBCClient.html[JDBCClient]`, you can merge configuration: the record location, the metadata and a json object provided by
 the consumer:
 
 [source, java]
@@ -744,7 +744,7 @@ discovery.getRecord(
     });
 ----
 
-You can also use the `link:../../apidocs/io/vertx/ext/jdbc/JDBCClient.html[JDBCClient]` class to to the lookup and retrieval in one call:
+You can also use the `link:../../apidocs/io/vertx/ext/jdbc/JDBCClient.html[JDBCClient]` class to the lookup and retrieval in one call:
 
 [source, java]
 ----
@@ -778,7 +778,7 @@ The received record has a `status` field indicating the new state of the record:
 == Listening for service usage
 
 Every time a service reference is retrieved (`bind`) or released (`release`), an event is published on the _vertx
-.discovery.usage` address. This address is configurable from the `link:../../apidocs/io/vertx/servicediscovery/ServiceDiscoveryOptions.html[ServiceDiscoveryOptions]`.
+.discovery.usage_ address. This address is configurable from the `link:../../apidocs/io/vertx/servicediscovery/ServiceDiscoveryOptions.html[ServiceDiscoveryOptions]`.
 
 It lets you listen for service usage and map the service bindings.
 
@@ -797,7 +797,7 @@ You can disable the service usage support by setting the usage address to `null`
 
 == Service discovery bridges
 
-Bridges let import and export services from / to other discovery mechanism such as Docker, Kubernates, Consul...
+Bridges let you import and export services from / to other discovery mechanism such as Docker, Kubernates, Consul...
 Each bridge decides how the services are imported and exported. It does not have to be bi-directional.
 
 You can provide your own bridge by implementing the `link:../../apidocs/io/vertx/servicediscovery/spi/ServiceImporter.html[ServiceImporter]` interface and
@@ -811,7 +811,7 @@ When the bridge is registered the
 {@link io.vertx.servicediscovery.spi.ServiceImporter#start)}
 method is called. It lets you configure the bridge. When the bridge is configured, ready and has imported /
 exported the initial services, it must complete the given `link:../../apidocs/io/vertx/core/Future.html[Future]`. If the bridge starts
-method is blocking, it must uses an
+method is blocking, it must use an
 `link:../../apidocs/io/vertx/core/Vertx.html#executeBlocking-io.vertx.core.Handler-boolean-io.vertx.core.Handler-[executeBlocking]` construct, and
 complete the given future object.
 

--- a/vertx-service-discovery/src/main/asciidoc/js/index.adoc
+++ b/vertx-service-discovery/src/main/asciidoc/js/index.adoc
@@ -9,7 +9,7 @@ service proxy, a HTTP endpoint and any other resource you can imagine as soon as
 with it. It does not have to be a vert.x entity, but can be anything. Each service is described by a
 `link:../dataobjects.html#Record[Record]`.
 
-The service discovery implements the interactions defined in the service-oriented computing. And to some extend,
+The service discovery implements the interactions defined in service-oriented computing. And to some extend,
 also provides the dynamic service-oriented computing interactions. So, applications can react to arrival and
 departure of services.
 
@@ -21,20 +21,20 @@ A service provider can:
 
 A service consumer can:
 
-* lookup for services
+* lookup services
 * bind to a selected service (it gets a `link:../../jsdoc/module-vertx-service-discovery-js_service_reference-ServiceReference.html[ServiceReference]`) and use it
 * release the service once the consumer is done with it
 * listen for arrival, departure and modification of services.
 
-Consumer would 1) lookup for service record matching their need, 2) retrieve the
+Consumer would 1) lookup a service record matching their need, 2) retrieve the
 `link:../../jsdoc/module-vertx-service-discovery-js_service_reference-ServiceReference.html[ServiceReference]` that give access to the service, 3) get a service object to access
 the service, 4) release the service object once done.
 
-A state above, the central piece of information shared by the providers and consumers are
+As stated above, the central piece of information shared by the providers and consumers are
 `link:../dataobjects.html#Record[records]`.
 
 Providers and consumers must create their own `link:../../jsdoc/module-vertx-service-discovery-js_service_discovery-ServiceDiscovery.html[ServiceDiscovery]` instance. These
-instances are collaborating in background (distributed structure) to keep the set of services in sync.
+instances are collaborating in the background (distributed structure) to keep the set of services in sync.
 
 The service discovery supports bridges to import and export services from / to other discovery technologies.
 
@@ -50,7 +50,7 @@ descriptor:
 <dependency>
 <groupId>io.vertx</groupId>
 <artifactId>vertx-service-discovery</artifactId>
-<version>3.3.0</version>
+<version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -58,7 +58,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery:3.3.0'
+compile 'io.vertx:vertx-service-discovery:3.3.1-SNAPSHOT'
 ----
 
 == Overall concepts
@@ -69,9 +69,9 @@ The discovery mechanism is based on a few concepts explained in this section.
 
 A service `link:../dataobjects.html#Record[Record]` is an object that describes a service published by a service
 provider. It contains a name, some metadata, a location object (describing where is the service). This record is
-the only objects shared by the provider (having published it) and the consumer (retrieve it when doing a lookup).
+the only object shared by the provider (having published it) and the consumer (retrieve it when doing a lookup).
 
-The metadata and even the location format depends on the `service type` (see below).
+The metadata and even the location format depend on the `service type` (see below).
 
 A record is published when the provider is ready to be used, and withdrawn when the service provider is stopping.
 
@@ -91,12 +91,12 @@ It is important to release service references to cleanup the objects and update 
 
 === Service object
 
-The service object is the object that give access to a service. It has various form, such as a proxy, a client, or
-may even be non existent for some service type. The nature of the service object depends of the service type.
+The service object is the object that gives access to a service. It can come in various forms, such as a proxy, a client,
+and may even be non-existent for some service types. The nature of the service object depends on the service type.
 
 === Service types
 
-Services are resources, and it exists a wide variety of resources. They can be functional services, databases,
+Services are just resources, and they exist in wide variety. They can be functional services, databases,
 REST APIs, and so on. The Vert.x service discovery has the concept of service types to handle this heterogeneity.
 Each type defines:
 
@@ -231,20 +231,20 @@ the matching ones. In the first case, the first matching record is returned.
 Consumer can pass a filter to select the service. There are two ways to describe the filter:
 
 1. A function taking a `link:../dataobjects.html#Record[Record]` as parameter and returning a boolean
-2. This filter is a JSON object. Each entry of the given filter are checked against the record. All entry must
-match exactly the record. The entry can use the special `*` value to denotes a requirement on the key, but not on
+2. This filter is a JSON object. Each entry of the given filter is checked against the record. All entries must
+exactly match the record. The entry can use the special `*` value to denote a requirement on the key, but not on
 the value.
 
-Let's take some example of JSON filter:
+Let's see an example of a JSON filter:
 ----
-{ "name" = "a" } => matches records with name set fo "a"
+{ "name" = "a" } => matches records with name set to "a"
 { "color" = "*" } => matches records with "color" set
 { "color" = "red" } => only matches records with "color" set to "red"
 { "color" = "red", "name" = "a"} => only matches records with name set to "a", and color set to "red"
 ----
 
 If the JSON filter is not set (`null` or empty), it accepts all records. When using functions, to accept all
-records, you must return true regardless the record.
+records, you must return _true_ regardless the record.
 
 Here are some examples:
 
@@ -337,9 +337,9 @@ discovery.getRecords({
 
 ----
 
-You can retrieve a single record or all matching record with
+You can retrieve a single record or all matching records with
 `link:../../jsdoc/module-vertx-service-discovery-js_service_discovery-ServiceDiscovery.html#getRecords[getRecords]`.
-By default, record lookup does includes only records with a `status` set to `UP`. This can be overridden:
+By default, record lookup does include only records with a `status` set to `UP`. This can be overridden:
 
 * when using JSON filter, just set `status` to the value you want (or `*` to accept all status)
 * when using function, set the `includeOutOfService` parameter to `true` in
@@ -371,8 +371,8 @@ Don't forget to release the reference once done.
 The service reference represents a binding with the service provider.
 
 When retrieving a service reference you can pass a `JsonObject` used to configure the
-service object. It can contains various data about the service objects. Some service types do not needs additional
-configuration, some requires configuration (as data sources):
+service object. It can contain various data about the service object. Some service types do not needs additional
+configuration, some require configuration (as data sources):
 
 [source,js]
 ----
@@ -394,19 +394,19 @@ reference.release();
 A said above, the service discovery has the service type concept to manage the heterogeneity of the
 different services.
 
-Are provided by default:
+These types are provided by default:
 
-* `link:../../jsdoc/module-vertx-service-discovery-js_http_endpoint-HttpEndpoint.html[HttpEndpoint]` - for REST API, the service object is a
+* `link:../../jsdoc/module-vertx-service-discovery-js_http_endpoint-HttpEndpoint.html[HttpEndpoint]` - for REST API's, the service object is a
 `link:../../jsdoc/module-vertx-js_http_client-HttpClient.html[HttpClient]` configured on the host and port (the location is the url).
 * `link:../../jsdoc/module-vertx-service-discovery-js_event_bus_service-EventBusService.html[EventBusService]` - for service proxies, the service object is a proxy. Its
 type is the proxies interface (the location is the address).
-* `link:../../jsdoc/module-vertx-service-discovery-js_message_source-MessageSource.html[MessageSource]` - for message source (publisher), the service object is a
+* `link:../../jsdoc/module-vertx-service-discovery-js_message_source-MessageSource.html[MessageSource]` - for message sources (publisher), the service object is a
 `link:../../jsdoc/module-vertx-js_message_consumer-MessageConsumer.html[MessageConsumer]` (the location is the address).
 * `link:../../jsdoc/module-vertx-service-discovery-js_jdbc_data_source-JDBCDataSource.html[JDBCDataSource]` - for JDBC data sources, the service object is a
 `link:../../jsdoc/module-vertx-jdbc-js_jdbc_client-JDBCClient.html[JDBCClient]` (the configuration of the client is computed from the location, metadata and
 consumer configuration).
 
-This section gives details about service types and describes how can be used the default service types.
+This section gives details about service types in general and describes how to use the default service types.
 
 === Services with no type
 
@@ -428,7 +428,7 @@ objects are `link:../../jsdoc/module-vertx-js_http_client-HttpClient.html[HttpCl
 To publish a HTTP endpoint, you need a `link:../dataobjects.html#Record[Record]`. You can create the record using
 `link:../../jsdoc/module-vertx-service-discovery-js_http_endpoint-HttpEndpoint.html#createRecord[HttpEndpoint.createRecord]`.
 
-The next snippet illustrates hot to create `link:../dataobjects.html#Record[Record]` from
+The next snippet illustrates hot to create a `link:../dataobjects.html#Record[Record]` from
 `link:../../jsdoc/module-vertx-service-discovery-js_http_endpoint-HttpEndpoint.html[HttpEndpoint]`:
 
 [source, js]
@@ -447,7 +447,7 @@ var record2 = HttpEndpoint.createRecord("some-other-name", true, "localhost", 84
 
 ----
 
-When you run your service in a container or on the cloud, it may not knows its public IP and public port, so the
+When you run your service in a container or on the cloud, it may not know its public IP and public port, so the
 publication must be done by another entity having this info. Generally it's a bridge.
 
 ==== Consuming a HTTP endpoint
@@ -511,12 +511,12 @@ HttpEndpoint.getClient(discovery, {
 
 In this second version, the service object is released using
 `link:../../jsdoc/module-vertx-service-discovery-js_service_discovery-ServiceDiscovery.html#releaseServiceObject[ServiceDiscovery.releaseServiceObject]`,
-as you don't hold the service reference.
+so you no longer hold on to the service reference.
 
 === Event bus services
 
-Event bus services are service proxies. They implement async-RPC services on top of the event bus. When retrieved
-a service object from an event bus service, you get a service proxy in the right type. You can access helper
+Event bus services are service proxies. They implement async-RPC services on top of the event bus. When retrieving
+a service object from an event bus service, you get a service proxy of the right type. You can access helper
 methods from `link:../../jsdoc/module-vertx-service-discovery-js_event_bus_service-EventBusService.html[EventBusService]`.
 
 Notice that service proxies (service implementations and service interfaces) are developed in Java.
@@ -567,14 +567,14 @@ reference.release(); // release the service
 
 === Message source
 
-A message source is a component sending message on the event bus on a specific address. Message source clients are
+A message source is a component sending messages on the event bus on a specific address. Message source clients are
 `link:../../jsdoc/module-vertx-js_message_consumer-MessageConsumer.html[MessageConsumer]`.
 
 The _location_ or a message source service is the event bus address on which messages are sent.
 
 ==== Publishing a message source
 
-As for the other service types, publishing a message source is a 2-steps process:
+As for the other service types, publishing a message source is a 2-step process:
 
 1. create a record, using `link:../../jsdoc/module-vertx-service-discovery-js_message_source-MessageSource.html[MessageSource]`
 2. publish the record
@@ -658,12 +658,12 @@ MessageSource.getConsumer(discovery, {
 
 === JDBC Data source
 
-Data sources represents databases or data stores. JDBC data sources are a specialization for database accessible
+Data sources represents databases or data stores. JDBC data sources are a specialization for databases accessible
 using a JDBC driver. The client of a JDBC data source service is a `link:../../jsdoc/module-vertx-jdbc-js_jdbc_client-JDBCClient.html[JDBCClient]`.
 
 === Publishing a JDBC service
 
-As for the other service types, publishing a message source is a 2-steps process:
+As for the other service types, publishing a message source is a 2-step process:
 
 1. create a record, using `link:../../jsdoc/module-vertx-service-discovery-js_jdbc_data_source-JDBCDataSource.html[JDBCDataSource]`
 2. publish the record
@@ -685,13 +685,13 @@ discovery.publish(record, function (ar, ar_err) {
 
 As JDBC data sources can represent a high variety of databases, and their access is often different, the record is
 rather unstructured. The `location` is a simple JSON object that should provide the fields to access the data
-source (JDBC url, username...). The set of field may depends on the database but also on the connection pool use
+source (JDBC url, username...). The set of fields may depend on the database but also on the connection pool used
 in front.
 
 === Consuming a JDBC service
 
-As state in the previous section, accessible data source depends on the data source itself. To build the
-`link:../../jsdoc/module-vertx-jdbc-js_jdbc_client-JDBCClient.html[JDBCClient]`, are merged: the record location, the metadata and a json object provided by
+As stated in the previous section, how to access a data source depends on the data source itself. To build the
+`link:../../jsdoc/module-vertx-jdbc-js_jdbc_client-JDBCClient.html[JDBCClient]`, you can merge configuration: the record location, the metadata and a json object provided by
 the consumer:
 
 [source, js]
@@ -719,7 +719,7 @@ discovery.getRecord({
 
 ----
 
-You can also use the `link:../../jsdoc/module-vertx-jdbc-js_jdbc_client-JDBCClient.html[JDBCClient]` class to to the lookup and retrieval in one call:
+You can also use the `link:../../jsdoc/module-vertx-jdbc-js_jdbc_client-JDBCClient.html[JDBCClient]` class to the lookup and retrieval in one call:
 
 [source, js]
 ----
@@ -758,7 +758,7 @@ The received record has a `status` field indicating the new state of the record:
 == Listening for service usage
 
 Every time a service reference is retrieved (`bind`) or released (`release`), an event is published on the _vertx
-.discovery.usage` address. This address is configurable from the `link:../dataobjects.html#ServiceDiscoveryOptions[ServiceDiscoveryOptions]`.
+.discovery.usage_ address. This address is configurable from the `link:../dataobjects.html#ServiceDiscoveryOptions[ServiceDiscoveryOptions]`.
 
 It lets you listen for service usage and map the service bindings.
 
@@ -777,7 +777,7 @@ You can disable the service usage support by setting the usage address to `null`
 
 == Service discovery bridges
 
-Bridges let import and export services from / to other discovery mechanism such as Docker, Kubernates, Consul...
+Bridges let you import and export services from / to other discovery mechanism such as Docker, Kubernates, Consul...
 Each bridge decides how the services are imported and exported. It does not have to be bi-directional.
 
 You can provide your own bridge by implementing the `link:../../jsdoc/module-vertx-service-discovery-js_service_importer-ServiceImporter.html[ServiceImporter]` interface and
@@ -791,7 +791,7 @@ When the bridge is registered the
 {@link io.vertx.servicediscovery.spi.ServiceImporter#start)}
 method is called. It lets you configure the bridge. When the bridge is configured, ready and has imported /
 exported the initial services, it must complete the given `link:../../jsdoc/module-vertx-js_future-Future.html[Future]`. If the bridge starts
-method is blocking, it must uses an
+method is blocking, it must use an
 `link:../../jsdoc/module-vertx-js_vertx-Vertx.html#executeBlocking[executeBlocking]` construct, and
 complete the given future object.
 

--- a/vertx-service-discovery/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-service-discovery/src/main/asciidoc/ruby/index.adoc
@@ -9,7 +9,7 @@ service proxy, a HTTP endpoint and any other resource you can imagine as soon as
 with it. It does not have to be a vert.x entity, but can be anything. Each service is described by a
 `link:../dataobjects.html#Record[Record]`.
 
-The service discovery implements the interactions defined in the service-oriented computing. And to some extend,
+The service discovery implements the interactions defined in service-oriented computing. And to some extend,
 also provides the dynamic service-oriented computing interactions. So, applications can react to arrival and
 departure of services.
 
@@ -21,20 +21,20 @@ A service provider can:
 
 A service consumer can:
 
-* lookup for services
+* lookup services
 * bind to a selected service (it gets a `link:../../yardoc/VertxServiceDiscovery/ServiceReference.html[ServiceReference]`) and use it
 * release the service once the consumer is done with it
 * listen for arrival, departure and modification of services.
 
-Consumer would 1) lookup for service record matching their need, 2) retrieve the
+Consumer would 1) lookup a service record matching their need, 2) retrieve the
 `link:../../yardoc/VertxServiceDiscovery/ServiceReference.html[ServiceReference]` that give access to the service, 3) get a service object to access
 the service, 4) release the service object once done.
 
-A state above, the central piece of information shared by the providers and consumers are
+As stated above, the central piece of information shared by the providers and consumers are
 `link:../dataobjects.html#Record[records]`.
 
 Providers and consumers must create their own `link:../../yardoc/VertxServiceDiscovery/ServiceDiscovery.html[ServiceDiscovery]` instance. These
-instances are collaborating in background (distributed structure) to keep the set of services in sync.
+instances are collaborating in the background (distributed structure) to keep the set of services in sync.
 
 The service discovery supports bridges to import and export services from / to other discovery technologies.
 
@@ -50,7 +50,7 @@ descriptor:
 <dependency>
 <groupId>io.vertx</groupId>
 <artifactId>vertx-service-discovery</artifactId>
-<version>3.3.0</version>
+<version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -58,7 +58,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-discovery:3.3.0'
+compile 'io.vertx:vertx-service-discovery:3.3.1-SNAPSHOT'
 ----
 
 == Overall concepts
@@ -69,9 +69,9 @@ The discovery mechanism is based on a few concepts explained in this section.
 
 A service `link:../dataobjects.html#Record[Record]` is an object that describes a service published by a service
 provider. It contains a name, some metadata, a location object (describing where is the service). This record is
-the only objects shared by the provider (having published it) and the consumer (retrieve it when doing a lookup).
+the only object shared by the provider (having published it) and the consumer (retrieve it when doing a lookup).
 
-The metadata and even the location format depends on the `service type` (see below).
+The metadata and even the location format depend on the `service type` (see below).
 
 A record is published when the provider is ready to be used, and withdrawn when the service provider is stopping.
 
@@ -91,12 +91,12 @@ It is important to release service references to cleanup the objects and update 
 
 === Service object
 
-The service object is the object that give access to a service. It has various form, such as a proxy, a client, or
-may even be non existent for some service type. The nature of the service object depends of the service type.
+The service object is the object that gives access to a service. It can come in various forms, such as a proxy, a client,
+and may even be non-existent for some service types. The nature of the service object depends on the service type.
 
 === Service types
 
-Services are resources, and it exists a wide variety of resources. They can be functional services, databases,
+Services are just resources, and they exist in wide variety. They can be functional services, databases,
 REST APIs, and so on. The Vert.x service discovery has the concept of service types to handle this heterogeneity.
 Each type defines:
 
@@ -231,20 +231,20 @@ the matching ones. In the first case, the first matching record is returned.
 Consumer can pass a filter to select the service. There are two ways to describe the filter:
 
 1. A function taking a `link:../dataobjects.html#Record[Record]` as parameter and returning a boolean
-2. This filter is a JSON object. Each entry of the given filter are checked against the record. All entry must
-match exactly the record. The entry can use the special `*` value to denotes a requirement on the key, but not on
+2. This filter is a JSON object. Each entry of the given filter is checked against the record. All entries must
+exactly match the record. The entry can use the special `*` value to denote a requirement on the key, but not on
 the value.
 
-Let's take some example of JSON filter:
+Let's see an example of a JSON filter:
 ----
-{ "name" = "a" } => matches records with name set fo "a"
+{ "name" = "a" } => matches records with name set to "a"
 { "color" = "*" } => matches records with "color" set
 { "color" = "red" } => only matches records with "color" set to "red"
 { "color" = "red", "name" = "a"} => only matches records with name set to "a", and color set to "red"
 ----
 
 If the JSON filter is not set (`null` or empty), it accepts all records. When using functions, to accept all
-records, you must return true regardless the record.
+records, you must return _true_ regardless the record.
 
 Here are some examples:
 
@@ -337,9 +337,9 @@ discovery.get_records({
 
 ----
 
-You can retrieve a single record or all matching record with
+You can retrieve a single record or all matching records with
 `link:../../yardoc/VertxServiceDiscovery/ServiceDiscovery.html#get_records-instance_method[getRecords]`.
-By default, record lookup does includes only records with a `status` set to `UP`. This can be overridden:
+By default, record lookup does include only records with a `status` set to `UP`. This can be overridden:
 
 * when using JSON filter, just set `status` to the value you want (or `*` to accept all status)
 * when using function, set the `includeOutOfService` parameter to `true` in
@@ -371,8 +371,8 @@ Don't forget to release the reference once done.
 The service reference represents a binding with the service provider.
 
 When retrieving a service reference you can pass a `link:unavailable[JsonObject]` used to configure the
-service object. It can contains various data about the service objects. Some service types do not needs additional
-configuration, some requires configuration (as data sources):
+service object. It can contain various data about the service object. Some service types do not needs additional
+configuration, some require configuration (as data sources):
 
 [source,ruby]
 ----
@@ -394,19 +394,19 @@ reference.release()
 A said above, the service discovery has the service type concept to manage the heterogeneity of the
 different services.
 
-Are provided by default:
+These types are provided by default:
 
-* `link:../../yardoc/VertxServiceDiscovery/HttpEndpoint.html[HttpEndpoint]` - for REST API, the service object is a
+* `link:../../yardoc/VertxServiceDiscovery/HttpEndpoint.html[HttpEndpoint]` - for REST API's, the service object is a
 `link:../../yardoc/Vertx/HttpClient.html[HttpClient]` configured on the host and port (the location is the url).
 * `link:../../yardoc/VertxServiceDiscovery/EventBusService.html[EventBusService]` - for service proxies, the service object is a proxy. Its
 type is the proxies interface (the location is the address).
-* `link:../../yardoc/VertxServiceDiscovery/MessageSource.html[MessageSource]` - for message source (publisher), the service object is a
+* `link:../../yardoc/VertxServiceDiscovery/MessageSource.html[MessageSource]` - for message sources (publisher), the service object is a
 `link:../../yardoc/Vertx/MessageConsumer.html[MessageConsumer]` (the location is the address).
 * `link:../../yardoc/VertxServiceDiscovery/JDBCDataSource.html[JDBCDataSource]` - for JDBC data sources, the service object is a
 `link:../../yardoc/VertxJdbc/JDBCClient.html[JDBCClient]` (the configuration of the client is computed from the location, metadata and
 consumer configuration).
 
-This section gives details about service types and describes how can be used the default service types.
+This section gives details about service types in general and describes how to use the default service types.
 
 === Services with no type
 
@@ -428,7 +428,7 @@ objects are `link:../../yardoc/Vertx/HttpClient.html[HttpClient]` configured wit
 To publish a HTTP endpoint, you need a `link:../dataobjects.html#Record[Record]`. You can create the record using
 `link:../../yardoc/VertxServiceDiscovery/HttpEndpoint.html#create_record-class_method[HttpEndpoint.createRecord]`.
 
-The next snippet illustrates hot to create `link:../dataobjects.html#Record[Record]` from
+The next snippet illustrates hot to create a `link:../dataobjects.html#Record[Record]` from
 `link:../../yardoc/VertxServiceDiscovery/HttpEndpoint.html[HttpEndpoint]`:
 
 [source, ruby]
@@ -447,7 +447,7 @@ record2 = VertxServiceDiscovery::HttpEndpoint.create_record("some-other-name", t
 
 ----
 
-When you run your service in a container or on the cloud, it may not knows its public IP and public port, so the
+When you run your service in a container or on the cloud, it may not know its public IP and public port, so the
 publication must be done by another entity having this info. Generally it's a bridge.
 
 ==== Consuming a HTTP endpoint
@@ -511,12 +511,12 @@ VertxServiceDiscovery::HttpEndpoint.get_client(discovery, {
 
 In this second version, the service object is released using
 `link:../../yardoc/VertxServiceDiscovery/ServiceDiscovery.html#release_service_object-class_method[ServiceDiscovery.releaseServiceObject]`,
-as you don't hold the service reference.
+so you no longer hold on to the service reference.
 
 === Event bus services
 
-Event bus services are service proxies. They implement async-RPC services on top of the event bus. When retrieved
-a service object from an event bus service, you get a service proxy in the right type. You can access helper
+Event bus services are service proxies. They implement async-RPC services on top of the event bus. When retrieving
+a service object from an event bus service, you get a service proxy of the right type. You can access helper
 methods from `link:../../yardoc/VertxServiceDiscovery/EventBusService.html[EventBusService]`.
 
 Notice that service proxies (service implementations and service interfaces) are developed in Java.
@@ -548,14 +548,14 @@ TODO
 
 === Message source
 
-A message source is a component sending message on the event bus on a specific address. Message source clients are
+A message source is a component sending messages on the event bus on a specific address. Message source clients are
 `link:../../yardoc/Vertx/MessageConsumer.html[MessageConsumer]`.
 
 The _location_ or a message source service is the event bus address on which messages are sent.
 
 ==== Publishing a message source
 
-As for the other service types, publishing a message source is a 2-steps process:
+As for the other service types, publishing a message source is a 2-step process:
 
 1. create a record, using `link:../../yardoc/VertxServiceDiscovery/MessageSource.html[MessageSource]`
 2. publish the record
@@ -639,12 +639,12 @@ VertxServiceDiscovery::MessageSource.get_consumer(discovery, {
 
 === JDBC Data source
 
-Data sources represents databases or data stores. JDBC data sources are a specialization for database accessible
+Data sources represents databases or data stores. JDBC data sources are a specialization for databases accessible
 using a JDBC driver. The client of a JDBC data source service is a `link:../../yardoc/VertxJdbc/JDBCClient.html[JDBCClient]`.
 
 === Publishing a JDBC service
 
-As for the other service types, publishing a message source is a 2-steps process:
+As for the other service types, publishing a message source is a 2-step process:
 
 1. create a record, using `link:../../yardoc/VertxServiceDiscovery/JDBCDataSource.html[JDBCDataSource]`
 2. publish the record
@@ -666,13 +666,13 @@ discovery.publish(record) { |ar_err,ar|
 
 As JDBC data sources can represent a high variety of databases, and their access is often different, the record is
 rather unstructured. The `location` is a simple JSON object that should provide the fields to access the data
-source (JDBC url, username...). The set of field may depends on the database but also on the connection pool use
+source (JDBC url, username...). The set of fields may depend on the database but also on the connection pool used
 in front.
 
 === Consuming a JDBC service
 
-As state in the previous section, accessible data source depends on the data source itself. To build the
-`link:../../yardoc/VertxJdbc/JDBCClient.html[JDBCClient]`, are merged: the record location, the metadata and a json object provided by
+As stated in the previous section, how to access a data source depends on the data source itself. To build the
+`link:../../yardoc/VertxJdbc/JDBCClient.html[JDBCClient]`, you can merge configuration: the record location, the metadata and a json object provided by
 the consumer:
 
 [source, ruby]
@@ -700,7 +700,7 @@ discovery.get_record({
 
 ----
 
-You can also use the `link:../../yardoc/VertxJdbc/JDBCClient.html[JDBCClient]` class to to the lookup and retrieval in one call:
+You can also use the `link:../../yardoc/VertxJdbc/JDBCClient.html[JDBCClient]` class to the lookup and retrieval in one call:
 
 [source, ruby]
 ----
@@ -739,7 +739,7 @@ The received record has a `status` field indicating the new state of the record:
 == Listening for service usage
 
 Every time a service reference is retrieved (`bind`) or released (`release`), an event is published on the _vertx
-.discovery.usage` address. This address is configurable from the `link:../dataobjects.html#ServiceDiscoveryOptions[ServiceDiscoveryOptions]`.
+.discovery.usage_ address. This address is configurable from the `link:../dataobjects.html#ServiceDiscoveryOptions[ServiceDiscoveryOptions]`.
 
 It lets you listen for service usage and map the service bindings.
 
@@ -758,7 +758,7 @@ You can disable the service usage support by setting the usage address to `null`
 
 == Service discovery bridges
 
-Bridges let import and export services from / to other discovery mechanism such as Docker, Kubernates, Consul...
+Bridges let you import and export services from / to other discovery mechanism such as Docker, Kubernates, Consul...
 Each bridge decides how the services are imported and exported. It does not have to be bi-directional.
 
 You can provide your own bridge by implementing the `link:../../yardoc/VertxServiceDiscovery/ServiceImporter.html[ServiceImporter]` interface and
@@ -772,7 +772,7 @@ When the bridge is registered the
 {@link io.vertx.servicediscovery.spi.ServiceImporter#start)}
 method is called. It lets you configure the bridge. When the bridge is configured, ready and has imported /
 exported the initial services, it must complete the given `link:../../yardoc/Vertx/Future.html[Future]`. If the bridge starts
-method is blocking, it must uses an
+method is blocking, it must use an
 `link:../../yardoc/Vertx/Vertx.html#execute_blocking-instance_method[executeBlocking]` construct, and
 complete the given future object.
 

--- a/vertx-service-discovery/src/main/java/io/vertx/servicediscovery/package-info.java
+++ b/vertx-service-discovery/src/main/java/io/vertx/servicediscovery/package-info.java
@@ -16,50 +16,50 @@
 
 /**
  * = Vert.x Service Discovery
- * 
+ *
  * This components provides an infrastructure to publish and discover various resources, such as service
  * proxies, HTTP endpoints, data sources... These resources are called `services`. A `service` is a discoverable
  * functionality. It can be qualified by its type, metadata, and location. So a `service` can be a database, a
  * service proxy, a HTTP endpoint and any other resource you can imagine as soon as you can describe it and interact
  * with it. It does not have to be a vert.x entity, but can be anything. Each service is described by a
  * {@link io.vertx.servicediscovery.Record}.
- * 
- * The service discovery implements the interactions defined in the service-oriented computing. And to some extend,
+ *
+ * The service discovery implements the interactions defined in service-oriented computing. And to some extend,
  * also provides the dynamic service-oriented computing interactions. So, applications can react to arrival and
  * departure of services.
- * 
+ *
  * A service provider can:
- * 
+ *
  * * publish a service record
  * * un-publish a published record
  * * update the status of a published service (down, out of service...)
- * 
+ *
  * A service consumer can:
- * 
- * * lookup for services
+ *
+ * * lookup services
  * * bind to a selected service (it gets a {@link io.vertx.servicediscovery.ServiceReference}) and use it
  * * release the service once the consumer is done with it
  * * listen for arrival, departure and modification of services.
- * 
- * Consumer would 1) lookup for service record matching their need, 2) retrieve the
+ *
+ * Consumer would 1) lookup a service record matching their need, 2) retrieve the
  * {@link io.vertx.servicediscovery.ServiceReference} that give access to the service, 3) get a service object to access
  * the service, 4) release the service object once done.
- * 
- * A state above, the central piece of information shared by the providers and consumers are
+ *
+ * As stated above, the central piece of information shared by the providers and consumers are
  * {@link io.vertx.servicediscovery.Record records}.
- * 
+ *
  * Providers and consumers must create their own {@link io.vertx.servicediscovery.ServiceDiscovery} instance. These
- * instances are collaborating in background (distributed structure) to keep the set of services in sync.
- * 
+ * instances are collaborating in the background (distributed structure) to keep the set of services in sync.
+ *
  * The service discovery supports bridges to import and export services from / to other discovery technologies.
- * 
+ *
  * == Using the service discovery
- * 
+ *
  * To use the Vert.x service discovery, add the following dependency to the _dependencies_ section of your build
  * descriptor:
- * 
+ *
  * * Maven (in your `pom.xml`):
- * 
+ *
  * [source,xml,subs="+attributes"]
  * ----
  * <dependency>
@@ -68,61 +68,61 @@
  * <version>${maven.version}</version>
  * </dependency>
  * ----
- * 
+ *
  * * Gradle (in your `build.gradle` file):
- * 
+ *
  * [source,groovy,subs="+attributes"]
  * ----
  * compile '${maven.groupId}:${maven.artifactId}:${maven.version}'
  * ----
- * 
+ *
  * == Overall concepts
- * 
+ *
  * The discovery mechanism is based on a few concepts explained in this section.
- * 
+ *
  * === Service records
- * 
+ *
  * A service {@link io.vertx.servicediscovery.Record} is an object that describes a service published by a service
  * provider. It contains a name, some metadata, a location object (describing where is the service). This record is
- * the only objects shared by the provider (having published it) and the consumer (retrieve it when doing a lookup).
- * 
- * The metadata and even the location format depends on the `service type` (see below).
- * 
+ * the only object shared by the provider (having published it) and the consumer (retrieve it when doing a lookup).
+ *
+ * The metadata and even the location format depend on the `service type` (see below).
+ *
  * A record is published when the provider is ready to be used, and withdrawn when the service provider is stopping.
- * 
+ *
  * === Service Provider and publisher
- * 
+ *
  * A service provider is an entity providing a _service_. The publisher is responsible for publishing a record
  * describing the provider. It may be a single entity (a provider publishing itself) or a different entity.
- * 
+ *
  * === Service Consumer
- * 
+ *
  * Service consumers search for services in the service discovery. Each lookup retrieves `0..n`
  * {@link io.vertx.servicediscovery.Record}. From these records, a consumer can retrieve a
  * {@link io.vertx.servicediscovery.ServiceReference}, representing the binding between the consumer and the provider.
  * This reference allows the consumer to retrieve the _service object_ (to use the service),  and release the service.
  *
  * It is important to release service references to cleanup the objects and update the service usages.
- * 
+ *
  * === Service object
- * 
- * The service object is the object that give access to a service. It has various form, such as a proxy, a client, or
- * may even be non existent for some service type. The nature of the service object depends of the service type.
- * 
+ *
+ * The service object is the object that gives access to a service. It can come in various forms, such as a proxy, a client,
+ * and may even be non-existent for some service types. The nature of the service object depends on the service type.
+ *
  * === Service types
- * 
- * Services are resources, and it exists a wide variety of resources. They can be functional services, databases,
+ *
+ * Services are just resources, and they exist in wide variety. They can be functional services, databases,
  * REST APIs, and so on. The Vert.x service discovery has the concept of service types to handle this heterogeneity.
  * Each type defines:
- * 
+ *
  * * how the service is located (URI, event bus address, IP / DNS...)
  * * the nature of the service object (service proxy, HTTP client, message consumer...)
- * 
+ *
  * Some service types are implemented and provided by the service discovery component, but you can add
  * your own.
- * 
+ *
  * === Service events
- * 
+ *
  * Every time a service provider is published or withdrawn, an event is fired on the event bus. This event contains
  * the record that has been modified.
  *
@@ -132,139 +132,139 @@
  * service usages.
  *
  * More details on these events below.
- * 
+ *
  * === Backend
- * 
+ *
  * The service discovery uses a distributed structure to store the records. So, all members of the cluster have access
  * to all the records. This is the default backend implementation. You can implement your own by implementing the
  * {@link io.vertx.servicediscovery.spi.ServiceDiscoveryBackend} SPI.
  *
  * Notice that the discovery does not require vert.x clustering. In single-node mode, the map is a local map. It can
  * be populated with {@link io.vertx.servicediscovery.spi.ServiceImporter}s.
- * 
+ *
  * == Creating a service discovery instance
- * 
+ *
  * Publishers and consumers must create their own {@link io.vertx.servicediscovery.ServiceDiscovery}
  * instance to use the discovery infrastructure:
- * 
+ *
  * [source,$lang]
  * ----
  * {@link examples.Examples#example1(io.vertx.core.Vertx)}
  * ----
- * 
+ *
  * By default, the announce address (the event bus address on which service events are sent is: `vertx.discovery
  * .announce`. You can also configure a name used for the service usage (see section about service usage).
- * 
+ *
  * When you don't need the service discovery object anymore, don't forget to close it. It closes the different discovery bridges you
  * have configured and releases the service references.
- * 
+ *
  * == Publishing services
- * 
+ *
  * Once you have a service discovery instance, you can start to publish services. The process is the following:
- * 
+ *
  * 1. create a record for a specific service provider
  * 2. publish this record
  * 3. keep the published record that is used to un-publish a service or modify it.
- * 
+ *
  * To create records, you can either use the {@link io.vertx.servicediscovery.Record} class, or use convenient methods
  * from the service types.
- * 
+ *
  * [source,$lang]
  * ----
  * {@link examples.Examples#example2(ServiceDiscovery)}
  * ----
- * 
+ *
  * It is important to keep a reference on the returned records, as this record has been extended by a `registration id`.
- * 
+ *
  * == Withdrawing services
- * 
+ *
  * To withdraw (un-publish) a record, use:
- * 
+ *
  * [source,$lang]
  * ----
  * {@link examples.Examples#example3(ServiceDiscovery, Record)}
  * ----
- * 
+ *
  * == Looking for service
- * 
+ *
  * On the consumer side, the first thing to do is to lookup for records. You can search for a single record or all
  * the matching ones. In the first case, the first matching record is returned.
- * 
+ *
  * Consumer can pass a filter to select the service. There are two ways to describe the filter:
  *
  * 1. A function taking a {@link io.vertx.servicediscovery.Record} as parameter and returning a boolean
- * 2. This filter is a JSON object. Each entry of the given filter are checked against the record. All entry must
- * match exactly the record. The entry can use the special `*` value to denotes a requirement on the key, but not on
+ * 2. This filter is a JSON object. Each entry of the given filter is checked against the record. All entries must
+ * exactly match the record. The entry can use the special `*` value to denote a requirement on the key, but not on
  * the value.
- * 
- * Let's take some example of JSON filter:
+ *
+ * Let's see an example of a JSON filter:
  * ----
- * { "name" = "a" } => matches records with name set fo "a"
+ * { "name" = "a" } => matches records with name set to "a"
  * { "color" = "*" } => matches records with "color" set
  * { "color" = "red" } => only matches records with "color" set to "red"
  * { "color" = "red", "name" = "a"} => only matches records with name set to "a", and color set to "red"
  * ----
- * 
+ *
  * If the JSON filter is not set ({@code null} or empty), it accepts all records. When using functions, to accept all
- * records, you must return true regardless the record.
- * 
+ * records, you must return _true_ regardless the record.
+ *
  * Here are some examples:
- * 
+ *
  * [source,$lang]
  * ----
  * {@link examples.Examples#example4(ServiceDiscovery)}
  * ----
  *
- * You can retrieve a single record or all matching record with
+ * You can retrieve a single record or all matching records with
  * {@link io.vertx.servicediscovery.ServiceDiscovery#getRecords(io.vertx.core.json.JsonObject, io.vertx.core.Handler)}.
- * By default, record lookup does includes only records with a `status` set to `UP`. This can be overridden:
+ * By default, record lookup does include only records with a `status` set to `UP`. This can be overridden:
  *
  * * when using JSON filter, just set `status` to the value you want (or `*` to accept all status)
  * * when using function, set the `includeOutOfService` parameter to `true` in
  * {@link io.vertx.servicediscovery.ServiceDiscovery#getRecords(java.util.function.Function, boolean, io.vertx.core.Handler)}
  * .
- * 
+ *
  * == Retrieving a service reference
- * 
+ *
  * Once you have chosen the {@link io.vertx.servicediscovery.Record}, you can retrieve a
  * {@link io.vertx.servicediscovery.ServiceReference} and then the service object:
- * 
+ *
  * [source,$lang]
  * ----
  * {@link examples.Examples#example5(ServiceDiscovery, Record)}
  * ----
- * 
+ *
  * Don't forget to release the reference once done.
  *
  * The service reference represents a binding with the service provider.
  *
  * When retrieving a service reference you can pass a {@link io.vertx.core.json.JsonObject} used to configure the
- * service object. It can contains various data about the service objects. Some service types do not needs additional
- * configuration, some requires configuration (as data sources):
+ * service object. It can contain various data about the service object. Some service types do not needs additional
+ * configuration, some require configuration (as data sources):
  *
  * [source,$lang]
  * ----
  * {@link examples.Examples#example51(ServiceDiscovery, Record, io.vertx.core.json.JsonObject)}
  * ----
- * 
+ *
  * == Types of services
- * 
+ *
  * A said above, the service discovery has the service type concept to manage the heterogeneity of the
  * different services.
- * 
- * Are provided by default:
- * 
- * * {@link io.vertx.servicediscovery.types.HttpEndpoint} - for REST API, the service object is a
+ *
+ * These types are provided by default:
+ *
+ * * {@link io.vertx.servicediscovery.types.HttpEndpoint} - for REST API's, the service object is a
  * {@link io.vertx.core.http.HttpClient} configured on the host and port (the location is the url).
  * * {@link io.vertx.servicediscovery.types.EventBusService} - for service proxies, the service object is a proxy. Its
  * type is the proxies interface (the location is the address).
- * * {@link io.vertx.servicediscovery.types.MessageSource} - for message source (publisher), the service object is a
+ * * {@link io.vertx.servicediscovery.types.MessageSource} - for message sources (publisher), the service object is a
  * {@link io.vertx.core.eventbus.MessageConsumer} (the location is the address).
  * * {@link io.vertx.servicediscovery.types.JDBCDataSource} - for JDBC data sources, the service object is a
  * {@link io.vertx.ext.jdbc.JDBCClient} (the configuration of the client is computed from the location, metadata and
  * consumer configuration).
  *
- * This section gives details about service types and describes how can be used the default service types.
+ * This section gives details about service types in general and describes how to use the default service types.
  *
  * === Services with no type
  *
@@ -277,26 +277,26 @@
  * [language, java]
  * ----
  * === Implementing your own service type
- * 
+ *
  * You can create your own service type by implementing the {@link io.vertx.servicediscovery.spi.ServiceType} SPI:
  *
  * 1. (optional) Create a public interface extending {@link io.vertx.servicediscovery.spi.ServiceType}. This interface is
  * only used to provide helper methods to ease the usage of your type such as `createRecord` methods, `getX` where `X`
  * is the type of service object you retrieve and so on. Check {@link io.vertx.servicediscovery.types.HttpEndpoint} or
- * {@link io.vertx.servicediscovery.types.MessageSource} for examples
- * 2. Create a class implementing {@link io.vertx.servicediscovery.spi.ServiceType} or the interface you created in the
+ * {@link io.vertx.servicediscovery.types.MessageSource} for example
+ * 2. Create a class implementing {@link io.vertx.servicediscovery.spi.ServiceType} or the interface you created in
  * step 1. The type has a `name`, and a method to create the {@link io.vertx.servicediscovery.ServiceReference} for this
  * type. The name must match the `type` field of the {@link io.vertx.servicediscovery.Record} associated with your type.
- * 3. Create a class extending `io.vertx.ext.discovery.types.AbstractServiceReference`. You can parameterized
+ * 3. Create a class extending `io.vertx.ext.discovery.types.AbstractServiceReference`. You can parameterize
  * the class with the type of service object your are going to return. You must implement
- * `AbstractServiceReference#retrieve()` that create the service object. This
+ * `AbstractServiceReference#retrieve()` that creates the service object. This
  * method is only called once. If your service object needs cleanup, also override
  * `AbstractServiceReference#close()`.
  * 4. Create a `META-INF/services/io.vertx.ext.discovery.spi.ServiceType` file that is packaged in your jar. In this
  * file, just indicate the fully qualified name of the class created at step 2.
  * 5. Creates a jar containing the service type interface (step 1), the implementation (step 2 and 3) and the
  * service descriptor file (step 4). Put this jar in the classpath of your application. Here you go, your service
- * type is available.
+ * type is now available.
  * ----
  *
  * === HTTP endpoints
@@ -309,7 +309,7 @@
  * To publish a HTTP endpoint, you need a {@link io.vertx.servicediscovery.Record}. You can create the record using
  * {@link io.vertx.servicediscovery.types.HttpEndpoint#createRecord(java.lang.String, java.lang.String, int, java.lang.String, io.vertx.core.json.JsonObject)}.
  *
- * The next snippet illustrates hot to create {@link io.vertx.servicediscovery.Record} from
+ * The next snippet illustrates hot to create a {@link io.vertx.servicediscovery.Record} from
  * {@link io.vertx.servicediscovery.types.HttpEndpoint}:
  *
  * [source, $lang]
@@ -317,7 +317,7 @@
  * {@link examples.HTTPEndpointExamples#example1(ServiceDiscovery)}
  * ----
  *
- * When you run your service in a container or on the cloud, it may not knows its public IP and public port, so the
+ * When you run your service in a container or on the cloud, it may not know its public IP and public port, so the
  * publication must be done by another entity having this info. Generally it's a bridge.
  *
  * ==== Consuming a HTTP endpoint
@@ -341,12 +341,12 @@
  *
  * In this second version, the service object is released using
  * {@link io.vertx.servicediscovery.ServiceDiscovery#releaseServiceObject(ServiceDiscovery, java.lang.Object)},
- * as you don't hold the service reference.
+ * so you no longer hold on to the service reference.
  *
  * === Event bus services
  *
- * Event bus services are service proxies. They implement async-RPC services on top of the event bus. When retrieved
- * a service object from an event bus service, you get a service proxy in the right type. You can access helper
+ * Event bus services are service proxies. They implement async-RPC services on top of the event bus. When retrieving
+ * a service object from an event bus service, you get a service proxy of the right type. You can access helper
  * methods from {@link io.vertx.servicediscovery.types.EventBusService}.
  *
  * Notice that service proxies (service implementations and service interfaces) are developed in Java.
@@ -362,7 +362,7 @@
  *
  * [language, java]
  * ----
- * You can also pass the service interface as class too:
+ * You can also pass the service interface as class:
  *
  * [source, java]
  * \----
@@ -374,9 +374,9 @@
  * [language, java]
  * ----
  * To consume an event bus service you can either retrieve the record and then get the reference, or use the
- * {@link io.vertx.servicediscovery.types.EventBusService} interface that combine the two operations in one call.
+ * {@link io.vertx.servicediscovery.types.EventBusService} interface that combines the two operations in one call.
  *
- * When using the reference, you would do somehting like:
+ * When using the reference, you would do something like:
  * [source, java]
  * \----
  * {@link examples.EventBusServiceExamples#example2(ServiceDiscovery)}
@@ -393,7 +393,7 @@
  * To consume an event bus service you can either retrieve the record and then get the reference, or use the
  * {@link io.vertx.servicediscovery.types.EventBusService} interface that combines the two operations in one call.
  *
- * However, as the service is search by (Java) interface, you need to specify the type of client you expect.
+ * However, as the service is searched by (Java) interface, you need to specify the type of client you expect.
  *
  * [source, groovy]
  * \----
@@ -439,14 +439,14 @@
  * ----
  * === Message source
  *
- * A message source is a component sending message on the event bus on a specific address. Message source clients are
+ * A message source is a component sending messages on the event bus on a specific address. Message source clients are
  * {@link io.vertx.core.eventbus.MessageConsumer}.
  *
  * The _location_ or a message source service is the event bus address on which messages are sent.
  *
  * ==== Publishing a message source
  *
- * As for the other service types, publishing a message source is a 2-steps process:
+ * As for the other service types, publishing a message source is a 2-step process:
  *
  * 1. create a record, using {@link io.vertx.servicediscovery.types.MessageSource}
  * 2. publish the record
@@ -489,12 +489,12 @@
  *
  * === JDBC Data source
  *
- * Data sources represents databases or data stores. JDBC data sources are a specialization for database accessible
+ * Data sources represents databases or data stores. JDBC data sources are a specialization for databases accessible
  * using a JDBC driver. The client of a JDBC data source service is a {@link io.vertx.ext.jdbc.JDBCClient}.
  *
  * === Publishing a JDBC service
  *
- * As for the other service types, publishing a message source is a 2-steps process:
+ * As for the other service types, publishing a message source is a 2-step process:
  *
  * 1. create a record, using {@link io.vertx.servicediscovery.types.JDBCDataSource}
  * 2. publish the record
@@ -506,13 +506,13 @@
  *
  * As JDBC data sources can represent a high variety of databases, and their access is often different, the record is
  * rather unstructured. The `location` is a simple JSON object that should provide the fields to access the data
- * source (JDBC url, username...). The set of field may depends on the database but also on the connection pool use
+ * source (JDBC url, username...). The set of fields may depend on the database but also on the connection pool used
  * in front.
  *
  * === Consuming a JDBC service
  *
- * As state in the previous section, accessible data source depends on the data source itself. To build the
- * {@link io.vertx.ext.jdbc.JDBCClient}, are merged: the record location, the metadata and a json object provided by
+ * As stated in the previous section, how to access a data source depends on the data source itself. To build the
+ * {@link io.vertx.ext.jdbc.JDBCClient}, you can merge configuration: the record location, the metadata and a json object provided by
  * the consumer:
  *
  * [source, $lang]
@@ -520,20 +520,20 @@
  * {@link examples.JDBCDataSourceExamples#example2(ServiceDiscovery)}
  * ----
  *
- * You can also use the {@link io.vertx.ext.jdbc.JDBCClient} class to to the lookup and retrieval in one call:
+ * You can also use the {@link io.vertx.ext.jdbc.JDBCClient} class to the lookup and retrieval in one call:
  *
  * [source, $lang]
  * ----
  * {@link examples.JDBCDataSourceExamples#example3(ServiceDiscovery)}
  * ----
- * 
+ *
  * == Listening for service arrivals and departures
- * 
+ *
  * Every time a provider is published or removed, an event is published on the _vertx.discovery.announce_ address.
  * This address is configurable from the {@link io.vertx.servicediscovery.ServiceDiscoveryOptions}.
- * 
+ *
  * The received record has a `status` field indicating the new state of the record:
- * 
+ *
  * * `UP` : the service is available, you can start using it
  * * `DOWN` : the service is not available anymore, you should not use it anymore
  * * `OUT_OF_SERVICE` : the service is not running, you should not use it anymore, but it may come back later.
@@ -541,7 +541,7 @@
  * == Listening for service usage
  *
  * Every time a service reference is retrieved (`bind`) or released (`release`), an event is published on the _vertx
- * .discovery.usage` address. This address is configurable from the {@link io.vertx.servicediscovery.ServiceDiscoveryOptions}.
+ * .discovery.usage_ address. This address is configurable from the {@link io.vertx.servicediscovery.ServiceDiscoveryOptions}.
  *
  * It lets you listen for service usage and map the service bindings.
  *
@@ -557,12 +557,12 @@
  * You can disable the service usage support by setting the usage address to `null` with
  * {@link io.vertx.servicediscovery.ServiceDiscoveryOptions#setUsageAddress(java.lang.String)}.
  *
- * 
+ *
  * == Service discovery bridges
- * 
- * Bridges let import and export services from / to other discovery mechanism such as Docker, Kubernates, Consul...
+ *
+ * Bridges let you import and export services from / to other discovery mechanism such as Docker, Kubernates, Consul...
  * Each bridge decides how the services are imported and exported. It does not have to be bi-directional.
- * 
+ *
  * You can provide your own bridge by implementing the {@link io.vertx.servicediscovery.spi.ServiceImporter} interface and
  * register it using
  * {@link io.vertx.servicediscovery.ServiceDiscovery#registerServiceImporter(ServiceImporter, io.vertx.core.json.JsonObject)}.
@@ -574,7 +574,7 @@
  * {@link io.vertx.servicediscovery.spi.ServiceImporter#start)}
  * method is called. It lets you configure the bridge. When the bridge is configured, ready and has imported /
  * exported the initial services, it must complete the given {@link io.vertx.core.Future}. If the bridge starts
- * method is blocking, it must uses an
+ * method is blocking, it must use an
  * {@link io.vertx.core.Vertx#executeBlocking(io.vertx.core.Handler, boolean, io.vertx.core.Handler)} construct, and
  * complete the given future object.
  *
@@ -582,7 +582,7 @@
  * {@link io.vertx.servicediscovery.spi.ServiceImporter#stop}
  * method is called that provides the opportunity to cleanup resources, removed imported / exported services... This
  * method must complete the given {@link io.vertx.core.Future} to notify the caller of the completion.
- * 
+ *
  * Notice than in a cluster, only one member needs to register the bridge as the records are accessible by all members.
  */
 @ModuleGen(name = "vertx-service-discovery", groupPackage = "io.vertx")


### PR DESCRIPTION
I started out fixing `_vertx.discovery.usage` and remove the underscore, because it may cause confusion, then decided to give the whole document a scan. Most changes are typos, but also changed couple of sentences that were unclear.

(Note I checked in the generated .adoc and .js files as well, because they already existed in this repo)