### PR TITLE
Zookeeper Service Importer and Backend

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     <module>vertx-service-discovery-bridge-docker-links</module>
     <module>vertx-service-discovery-backend-redis</module>
     <module>vertx-service-discovery-bridge-consul</module>
+    <module>vertx-service-discovery-bridge-zookeeper</module>
   </modules>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,4 @@
     </dependency>
   </dependencies>
 
-
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <module>vertx-service-discovery-backend-redis</module>
     <module>vertx-service-discovery-bridge-consul</module>
     <module>vertx-service-discovery-bridge-zookeeper</module>
+    <module>vertx-service-discovery-backend-zookeeper</module>
   </modules>
 
   <dependencyManagement>

--- a/vertx-service-discovery-backend-redis/pom.xml
+++ b/vertx-service-discovery-backend-redis/pom.xml
@@ -44,6 +44,13 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-service-discovery</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.kstyrc</groupId>
       <artifactId>embedded-redis</artifactId>
       <version>0.6</version>

--- a/vertx-service-discovery-backend-redis/src/test/java/io/vertx/servicediscovery/backend/redis/RedisBackendTest.java
+++ b/vertx-service-discovery-backend-redis/src/test/java/io/vertx/servicediscovery/backend/redis/RedisBackendTest.java
@@ -16,38 +16,20 @@
 
 package io.vertx.servicediscovery.backend.redis;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import io.vertx.servicediscovery.Record;
-import io.vertx.servicediscovery.Status;
-import org.junit.*;
+import io.vertx.servicediscovery.spi.ServiceDiscoveryBackend;
+import io.vertx.servicediscovery.spi.ServiceDiscoveryBackendTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import redis.embedded.RedisServer;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static com.jayway.awaitility.Awaitility.await;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
  */
-public class RedisBackendTest {
+public class RedisBackendTest extends ServiceDiscoveryBackendTest {
 
   private static final Integer DEFAULT_PORT = 6379;
   private static RedisServer server;
-
-  private static final Map<Integer, RedisServer> instances = new ConcurrentHashMap<>();
-
-  protected RedisBackendService backend;
-  protected Vertx vertx;
 
   @BeforeClass
   static public void startRedis() throws Exception {
@@ -62,170 +44,11 @@ public class RedisBackendTest {
     server.stop();
   }
 
-  @Before
-  public void setUp() {
-    vertx = Vertx.vertx();
-    backend = new RedisBackendService();
+  @Override
+  protected ServiceDiscoveryBackend createBackend() {
+    RedisBackendService backend = new RedisBackendService();
     backend.init(vertx, new JsonObject());
-  }
-
-  @After
-  public void tearDown() {
-    AtomicBoolean completed = new AtomicBoolean();
-    vertx.close(ar -> completed.set(ar.succeeded()));
-    await().untilAtomic(completed, is(true));
-  }
-
-  @Test
-  public void testInsertion() {
-    Record record = new Record().setName("my-service").setStatus(Status.UP);
-    assertThat(record.getRegistration()).isNull();
-
-    // Insertion
-    AtomicReference<Record> reference = new AtomicReference<>();
-    backend.store(record, ar -> {
-      if (!ar.succeeded()) {
-        ar.cause().printStackTrace();
-      }
-      reference.set(ar.result());
-    });
-
-    await().until(() -> reference.get() != null);
-    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
-    assertThat(reference.get().getRegistration()).isNotNull();
-    record = reference.get();
-
-    // Retrieve
-    reference.set(null);
-    backend.getRecord(record.getRegistration(), ar -> reference.set(ar.result()));
-    await().until(() -> reference.get() != null);
-    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
-    assertThat(reference.get().getRegistration()).isNotNull();
-
-    // Remove
-    AtomicBoolean completed = new AtomicBoolean();
-    backend.remove(record, ar -> {
-      completed.set(ar.succeeded());
-    });
-    await().untilAtomic(completed, is(true));
-
-    // Retrieve
-    completed.set(false);
-    reference.set(null);
-    backend.getRecord(record.getRegistration(), ar -> {
-      if (!ar.succeeded()) {
-        ar.cause().printStackTrace();
-      }
-      completed.set(ar.succeeded());
-      reference.set(ar.result());
-    });
-
-    await().untilAtomic(completed, is(true));
-    assertThat(reference.get()).isNull();
-  }
-
-  @Test
-  public void testInsertionFollowedByAnUpdate() {
-    Record record = new Record().setName("my-service").setStatus(Status.UP);
-    assertThat(record.getRegistration()).isNull();
-
-    // Insertion
-    AtomicReference<Record> reference = new AtomicReference<>();
-    backend.store(record, ar -> {
-      if (!ar.succeeded()) {
-        ar.cause().printStackTrace();
-      }
-      reference.set(ar.result());
-    });
-
-    await().until(() -> reference.get() != null);
-    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
-    assertThat(reference.get().getRegistration()).isNotNull();
-    record = reference.get();
-
-    // Retrieve
-    reference.set(null);
-    backend.getRecord(record.getRegistration(), ar -> reference.set(ar.result()));
-    await().until(() -> reference.get() != null);
-    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
-    assertThat(reference.get().getRegistration()).isNotNull();
-
-    // Update
-    AtomicBoolean completed = new AtomicBoolean();
-    record.getMetadata().put("some-new-key", "some-new-value");
-    backend.update(record, ar -> {
-      completed.set(ar.succeeded());
-    });
-    await().untilAtomic(completed, is(true));
-
-    // Retrieve
-    reference.set(null);
-    backend.getRecord(record.getRegistration(), ar -> reference.set(ar.result()));
-    await().until(() -> reference.get() != null);
-    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
-    assertThat(reference.get().getMetadata().getString("some-new-key"))
-        .isEqualToIgnoringCase("some-new-value");
-    assertThat(reference.get().getRegistration()).isNotNull();
-
-    // Remove
-    completed.set(false);
-    backend.remove(record, ar -> {
-      completed.set(ar.succeeded());
-    });
-    await().untilAtomic(completed, is(true));
-
-    // Retrieve
-    completed.set(false);
-    reference.set(null);
-    backend.getRecord(record.getRegistration(), ar -> {
-      if (!ar.succeeded()) {
-        ar.cause().printStackTrace();
-      }
-      completed.set(ar.succeeded());
-      reference.set(ar.result());
-    });
-
-    await().untilAtomic(completed, is(true));
-    assertThat(reference.get()).isNull();
-  }
-
-  @Test
-  public void testInsertionOfMultipleRecords() {
-    Record record1 = new Record().setName("my-service-1").setStatus(Status.UP);
-    assertThat(record1.getRegistration()).isNull();
-    Record record2 = new Record().setName("my-service-2").setStatus(Status.UP);
-    assertThat(record2.getRegistration()).isNull();
-    Record record3 = new Record().setName("my-service-3").setStatus(Status.UP);
-    assertThat(record3.getRegistration()).isNull();
-
-    // Insertion
-    AtomicBoolean completed = new AtomicBoolean();
-    backend.store(record1, ar -> {
-          backend.store(record2, ar2 -> {
-            backend.store(record3, ar3 -> {
-              completed.set(ar3.succeeded());
-            });
-          });
-        }
-    );
-
-    await().untilAtomic(completed, is(true));
-
-    List<Record> records = new ArrayList<>();
-    // Get records
-    backend.getRecords(ar -> {
-      records.addAll(ar.result());
-    });
-    await().until(() -> !records.isEmpty());
-
-    assertThat(records).hasSize(3);
-
-    // Get each records
-    for (Record record : records) {
-      AtomicReference<Record> retrieved = new AtomicReference<>();
-      backend.getRecord(record.getRegistration(), ar -> retrieved.set(ar.result()));
-      await().untilAtomic(retrieved, not(nullValue()));
-    }
+    return backend;
   }
 
 }

--- a/vertx-service-discovery-backend-zookeeper/pom.xml
+++ b/vertx-service-discovery-backend-zookeeper/pom.xml
@@ -10,7 +10,7 @@
     <version>3.4.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>vertx-service-discovery-bridge-zookeeper</artifactId>
+  <artifactId>vertx-service-discovery-backend-zookeeper</artifactId>
 
   <properties>
     <curator.version>2.11.0</curator.version>

--- a/vertx-service-discovery-backend-zookeeper/pom.xml
+++ b/vertx-service-discovery-backend-zookeeper/pom.xml
@@ -38,6 +38,13 @@
       <version>${curator.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-service-discovery</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/groovy/index.adoc
@@ -53,6 +53,8 @@ Additionally you can configure:
 * `maxRetries`: the number of connection attempt, 3 by default
 * `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
 1000 ms by default.
+* `connectionTimeoutMs`: the connection timeout in milliseconds. Defaults to 1000.
+* `canBeReadOnly` : whether or not the backend support the _read-only_ mode (defaults to false)
 * `basePath`: the Zookeeper path in which the service records are stored. Default to `/services`.
 * `ephemeral`: whether or not the created nodes are ephemeral nodes (see
 https://zookeeper.apache.org/doc/r3.4.5/zookeeperOver.html#Nodes+and+ephemeral+nodes). `false` by default

--- a/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/groovy/index.adoc
@@ -1,0 +1,1 @@
+== Vert.x Discovery Backend - Zookeeper

--- a/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/groovy/index.adoc
@@ -1,1 +1,85 @@
 == Vert.x Discovery Backend - Zookeeper
+
+The service discovery has a plug-able backend using the `ServiceDiscoveryBackend` SPI.
+
+This is an implementation of the SPI based
+on Apache Zookeeper.
+
+== Using the Zookeeper backend
+
+To use the Zookeeper backend, add the following dependency to the _dependencies_ section of your build
+descriptor:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>io.vertx</groupId>
+  <artifactId>vertx-service-discovery-backend-zookeeper</artifactId>
+  <version>3.4.0-SNAPSHOT</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile 'io.vertx:vertx-service-discovery-backend-zookeeper:3.4.0-SNAPSHOT'
+----
+
+Be aware that you can have only a single implementation of the SPI in your _classpath_. If none,
+the default backend is used.
+
+== Configuration
+
+There is a single mandatory configuration attribute: `connection`. Connection is the Zookeeper connection _string_.
+
+Here is an example:
+
+[source,groovy]
+----
+import io.vertx.groovy.servicediscovery.ServiceDiscovery
+ServiceDiscovery.create(vertx, [
+  backendConfiguration:[
+    connection:"127.0.0.1:2181"
+  ]
+])
+
+----
+
+Additionally you can configure:
+
+* `maxRetries`: the number of connection attempt, 3 by default
+* `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
+1000 ms by default.
+* `basePath`: the Zookeeper path in which the service records are stored. Default to `/services`.
+* `ephemeral`: whether or not the created nodes are ephemeral nodes (see
+https://zookeeper.apache.org/doc/r3.4.5/zookeeperOver.html#Nodes+and+ephemeral+nodes). `false` by default
+* `guaranteed`: whether or not to guarantee the node deletion even in case of failure. `false` by default
+
+[source,groovy]
+----
+import io.vertx.groovy.servicediscovery.ServiceDiscovery
+ServiceDiscovery.create(vertx, [
+  backendConfiguration:[
+    connection:"127.0.0.1:2181",
+    ephemeral:true,
+    guaranteed:true,
+    basePath:"/services/my-backend"
+  ]
+])
+
+----
+
+== How are stored the records
+
+The records are stored in individual nodes structured as follows:
+
+[source]
+----
+basepath (/services/)
+   |
+   |- record 1 registration id => the record 1 is the data of this node
+   |- record 2 registration id => the record 2 is the data of this node
+----

--- a/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/java/index.adoc
+++ b/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/java/index.adoc
@@ -1,1 +1,81 @@
 == Vert.x Discovery Backend - Zookeeper
+
+The service discovery has a plug-able backend using the `link:../../apidocs/io/vertx/servicediscovery/spi/ServiceDiscoveryBackend.html[ServiceDiscoveryBackend]` SPI.
+
+This is an implementation of the SPI based
+on Apache Zookeeper.
+
+== Using the Zookeeper backend
+
+To use the Zookeeper backend, add the following dependency to the _dependencies_ section of your build
+descriptor:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>io.vertx</groupId>
+  <artifactId>vertx-service-discovery-backend-zookeeper</artifactId>
+  <version>3.4.0-SNAPSHOT</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile 'io.vertx:vertx-service-discovery-backend-zookeeper:3.4.0-SNAPSHOT'
+----
+
+Be aware that you can have only a single implementation of the SPI in your _classpath_. If none,
+the default backend is used.
+
+== Configuration
+
+There is a single mandatory configuration attribute: `connection`. Connection is the Zookeeper connection _string_.
+
+Here is an example:
+
+[source,java]
+----
+ServiceDiscovery.create(vertx, new ServiceDiscoveryOptions()
+    .setBackendConfiguration(
+        new JsonObject()
+            .put("connection", "127.0.0.1:2181")
+    ));
+----
+
+Additionally you can configure:
+
+* `maxRetries`: the number of connection attempt, 3 by default
+* `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
+1000 ms by default.
+* `basePath`: the Zookeeper path in which the service records are stored. Default to `/services`.
+* `ephemeral`: whether or not the created nodes are ephemeral nodes (see
+https://zookeeper.apache.org/doc/r3.4.5/zookeeperOver.html#Nodes+and+ephemeral+nodes). `false` by default
+* `guaranteed`: whether or not to guarantee the node deletion even in case of failure. `false` by default
+
+[source,java]
+----
+ServiceDiscovery.create(vertx, new ServiceDiscoveryOptions()
+    .setBackendConfiguration(
+        new JsonObject()
+            .put("connection", "127.0.0.1:2181")
+            .put("ephemeral", true)
+            .put("guaranteed", true)
+            .put("basePath", "/services/my-backend")
+    ));
+----
+
+== How are stored the records
+
+The records are stored in individual nodes structured as follows:
+
+[source]
+----
+basepath (/services/)
+   |
+   |- record 1 registration id => the record 1 is the data of this node
+   |- record 2 registration id => the record 2 is the data of this node
+----

--- a/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/java/index.adoc
+++ b/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/java/index.adoc
@@ -1,0 +1,1 @@
+== Vert.x Discovery Backend - Zookeeper

--- a/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/java/index.adoc
+++ b/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/java/index.adoc
@@ -51,6 +51,8 @@ Additionally you can configure:
 * `maxRetries`: the number of connection attempt, 3 by default
 * `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
 1000 ms by default.
+* `connectionTimeoutMs`: the connection timeout in milliseconds. Defaults to 1000.
+* `canBeReadOnly` : whether or not the backend support the _read-only_ mode (defaults to false)
 * `basePath`: the Zookeeper path in which the service records are stored. Default to `/services`.
 * `ephemeral`: whether or not the created nodes are ephemeral nodes (see
 https://zookeeper.apache.org/doc/r3.4.5/zookeeperOver.html#Nodes+and+ephemeral+nodes). `false` by default

--- a/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/js/index.adoc
+++ b/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/js/index.adoc
@@ -53,6 +53,8 @@ Additionally you can configure:
 * `maxRetries`: the number of connection attempt, 3 by default
 * `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
 1000 ms by default.
+* `connectionTimeoutMs`: the connection timeout in milliseconds. Defaults to 1000.
+* `canBeReadOnly` : whether or not the backend support the _read-only_ mode (defaults to false)
 * `basePath`: the Zookeeper path in which the service records are stored. Default to `/services`.
 * `ephemeral`: whether or not the created nodes are ephemeral nodes (see
 https://zookeeper.apache.org/doc/r3.4.5/zookeeperOver.html#Nodes+and+ephemeral+nodes). `false` by default

--- a/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/js/index.adoc
+++ b/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/js/index.adoc
@@ -1,0 +1,1 @@
+== Vert.x Discovery Backend - Zookeeper

--- a/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/js/index.adoc
+++ b/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/js/index.adoc
@@ -1,1 +1,85 @@
 == Vert.x Discovery Backend - Zookeeper
+
+The service discovery has a plug-able backend using the `ServiceDiscoveryBackend` SPI.
+
+This is an implementation of the SPI based
+on Apache Zookeeper.
+
+== Using the Zookeeper backend
+
+To use the Zookeeper backend, add the following dependency to the _dependencies_ section of your build
+descriptor:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>io.vertx</groupId>
+  <artifactId>vertx-service-discovery-backend-zookeeper</artifactId>
+  <version>3.4.0-SNAPSHOT</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile 'io.vertx:vertx-service-discovery-backend-zookeeper:3.4.0-SNAPSHOT'
+----
+
+Be aware that you can have only a single implementation of the SPI in your _classpath_. If none,
+the default backend is used.
+
+== Configuration
+
+There is a single mandatory configuration attribute: `connection`. Connection is the Zookeeper connection _string_.
+
+Here is an example:
+
+[source,js]
+----
+var ServiceDiscovery = require("vertx-service-discovery-js/service_discovery");
+ServiceDiscovery.create(vertx, {
+  "backendConfiguration" : {
+    "connection" : "127.0.0.1:2181"
+  }
+});
+
+----
+
+Additionally you can configure:
+
+* `maxRetries`: the number of connection attempt, 3 by default
+* `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
+1000 ms by default.
+* `basePath`: the Zookeeper path in which the service records are stored. Default to `/services`.
+* `ephemeral`: whether or not the created nodes are ephemeral nodes (see
+https://zookeeper.apache.org/doc/r3.4.5/zookeeperOver.html#Nodes+and+ephemeral+nodes). `false` by default
+* `guaranteed`: whether or not to guarantee the node deletion even in case of failure. `false` by default
+
+[source,js]
+----
+var ServiceDiscovery = require("vertx-service-discovery-js/service_discovery");
+ServiceDiscovery.create(vertx, {
+  "backendConfiguration" : {
+    "connection" : "127.0.0.1:2181",
+    "ephemeral" : true,
+    "guaranteed" : true,
+    "basePath" : "/services/my-backend"
+  }
+});
+
+----
+
+== How are stored the records
+
+The records are stored in individual nodes structured as follows:
+
+[source]
+----
+basepath (/services/)
+   |
+   |- record 1 registration id => the record 1 is the data of this node
+   |- record 2 registration id => the record 2 is the data of this node
+----

--- a/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/ruby/index.adoc
@@ -53,6 +53,8 @@ Additionally you can configure:
 * `maxRetries`: the number of connection attempt, 3 by default
 * `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
 1000 ms by default.
+* `connectionTimeoutMs`: the connection timeout in milliseconds. Defaults to 1000.
+* `canBeReadOnly` : whether or not the backend support the _read-only_ mode (defaults to false)
 * `basePath`: the Zookeeper path in which the service records are stored. Default to `/services`.
 * `ephemeral`: whether or not the created nodes are ephemeral nodes (see
 https://zookeeper.apache.org/doc/r3.4.5/zookeeperOver.html#Nodes+and+ephemeral+nodes). `false` by default

--- a/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/ruby/index.adoc
@@ -1,1 +1,85 @@
 == Vert.x Discovery Backend - Zookeeper
+
+The service discovery has a plug-able backend using the `link:unavailable[ServiceDiscoveryBackend]` SPI.
+
+This is an implementation of the SPI based
+on Apache Zookeeper.
+
+== Using the Zookeeper backend
+
+To use the Zookeeper backend, add the following dependency to the _dependencies_ section of your build
+descriptor:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>io.vertx</groupId>
+  <artifactId>vertx-service-discovery-backend-zookeeper</artifactId>
+  <version>3.4.0-SNAPSHOT</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile 'io.vertx:vertx-service-discovery-backend-zookeeper:3.4.0-SNAPSHOT'
+----
+
+Be aware that you can have only a single implementation of the SPI in your _classpath_. If none,
+the default backend is used.
+
+== Configuration
+
+There is a single mandatory configuration attribute: `connection`. Connection is the Zookeeper connection _string_.
+
+Here is an example:
+
+[source,ruby]
+----
+require 'vertx-service-discovery/service_discovery'
+VertxServiceDiscovery::ServiceDiscovery.create(vertx, {
+  'backendConfiguration' => {
+    'connection' => "127.0.0.1:2181"
+  }
+})
+
+----
+
+Additionally you can configure:
+
+* `maxRetries`: the number of connection attempt, 3 by default
+* `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
+1000 ms by default.
+* `basePath`: the Zookeeper path in which the service records are stored. Default to `/services`.
+* `ephemeral`: whether or not the created nodes are ephemeral nodes (see
+https://zookeeper.apache.org/doc/r3.4.5/zookeeperOver.html#Nodes+and+ephemeral+nodes). `false` by default
+* `guaranteed`: whether or not to guarantee the node deletion even in case of failure. `false` by default
+
+[source,ruby]
+----
+require 'vertx-service-discovery/service_discovery'
+VertxServiceDiscovery::ServiceDiscovery.create(vertx, {
+  'backendConfiguration' => {
+    'connection' => "127.0.0.1:2181",
+    'ephemeral' => true,
+    'guaranteed' => true,
+    'basePath' => "/services/my-backend"
+  }
+})
+
+----
+
+== How are stored the records
+
+The records are stored in individual nodes structured as follows:
+
+[source]
+----
+basepath (/services/)
+   |
+   |- record 1 registration id => the record 1 is the data of this node
+   |- record 2 registration id => the record 2 is the data of this node
+----

--- a/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-service-discovery-backend-zookeeper/src/main/asciidoc/ruby/index.adoc
@@ -1,0 +1,1 @@
+== Vert.x Discovery Backend - Zookeeper

--- a/vertx-service-discovery-backend-zookeeper/src/main/java/examples/Examples.java
+++ b/vertx-service-discovery-backend-zookeeper/src/main/java/examples/Examples.java
@@ -1,0 +1,29 @@
+package examples;
+
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.servicediscovery.ServiceDiscovery;
+import io.vertx.servicediscovery.ServiceDiscoveryOptions;
+
+public class Examples {
+
+  public void configuration1(Vertx vertx) {
+    ServiceDiscovery.create(vertx, new ServiceDiscoveryOptions()
+        .setBackendConfiguration(
+            new JsonObject()
+                .put("connection", "127.0.0.1:2181")
+        ));
+  }
+
+  public void configuration2(Vertx vertx) {
+    ServiceDiscovery.create(vertx, new ServiceDiscoveryOptions()
+        .setBackendConfiguration(
+            new JsonObject()
+                .put("connection", "127.0.0.1:2181")
+                .put("ephemeral", true)
+                .put("guaranteed", true)
+                .put("basePath", "/services/my-backend")
+        ));
+  }
+}

--- a/vertx-service-discovery-backend-zookeeper/src/main/java/examples/package-info.java
+++ b/vertx-service-discovery-backend-zookeeper/src/main/java/examples/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2011-2016 The original author or authors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+@Source
+package examples;
+
+import io.vertx.docgen.Source;

--- a/vertx-service-discovery-backend-zookeeper/src/main/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendService.java
+++ b/vertx-service-discovery-backend-zookeeper/src/main/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendService.java
@@ -8,6 +8,8 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.framework.api.DeleteBuilder;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -17,30 +19,44 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
  */
-public class ZookeeperBackendService implements ServiceDiscoveryBackend {
+public class ZookeeperBackendService implements ServiceDiscoveryBackend, ConnectionStateListener {
 
   private static final Charset CHARSET = Charset.forName("UTF-8");
   private CuratorFramework client;
   private String basePath;
   private boolean ephemeral;
   private boolean guaranteed;
+  private Vertx vertx;
+  private ConnectionState connectionState = ConnectionState.LOST;
+  private boolean canBeReadOnly;
+  private int connectionTimeoutMs;
 
   @Override
   public void init(Vertx vertx, JsonObject configuration) {
+    this.vertx = vertx;
     String connection = Objects.requireNonNull(configuration.getString("connection"));
     int maxRetries = configuration.getInteger("maxRetries", 3);
     int baseGraceBetweenRetries = configuration
         .getInteger("baseSleepTimeBetweenRetries", 1000);
+    canBeReadOnly = configuration.getBoolean("canBeReadOnly", false);
+    connectionTimeoutMs = configuration.getInteger("connectionTimeoutMs", 1000);
     basePath = configuration.getString("basePath", "/services");
     ephemeral = configuration.getBoolean("ephemeral", false);
     guaranteed = configuration.getBoolean("guaranteed", false);
 
-    client = CuratorFrameworkFactory.newClient(connection,
-        new ExponentialBackoffRetry(baseGraceBetweenRetries, maxRetries));
+    client = CuratorFrameworkFactory.builder()
+        .canBeReadOnly(canBeReadOnly)
+        .connectString(connection)
+        .connectionTimeoutMs(connectionTimeoutMs)
+        .retryPolicy(new ExponentialBackoffRetry(baseGraceBetweenRetries, maxRetries))
+        .build();
+    client.getConnectionStateListenable().addListener(this);
     client.start();
   }
 
@@ -55,18 +71,25 @@ public class ZookeeperBackendService implements ServiceDiscoveryBackend {
 
     String content = record.toJson().encode();
     Context context = Vertx.currentContext();
-    try {
-      client.create()
-          .creatingParentsIfNeeded()
-          .withMode(ephemeral ? CreateMode.EPHEMERAL : CreateMode.PERSISTENT)
-          .inBackground((curatorFramework, curatorEvent)
-              -> callback(context, record, resultHandler, curatorEvent))
-          .withUnhandledErrorListener((s, throwable)
-              -> resultHandler.handle(Future.failedFuture(throwable)))
-          .forPath(getPath(record.getRegistration()), content.getBytes(CHARSET));
-    } catch (Exception e) {
-      resultHandler.handle(Future.failedFuture(e));
-    }
+
+    ensureConnected(x -> {
+      if (x.failed()) {
+        resultHandler.handle(Future.failedFuture(x.cause()));
+      } else {
+        try {
+          client.create()
+              .creatingParentsIfNeeded()
+              .withMode(ephemeral ? CreateMode.EPHEMERAL : CreateMode.PERSISTENT)
+              .inBackground((curatorFramework, curatorEvent)
+                  -> callback(context, record, resultHandler, curatorEvent))
+              .withUnhandledErrorListener((s, throwable)
+                  -> resultHandler.handle(Future.failedFuture(throwable)))
+              .forPath(getPath(record.getRegistration()), content.getBytes(CHARSET));
+        } catch (Exception e) {
+          resultHandler.handle(Future.failedFuture(e));
+        }
+      }
+    });
   }
 
   private String getPath(String registration) {
@@ -95,48 +118,62 @@ public class ZookeeperBackendService implements ServiceDiscoveryBackend {
   public void remove(String uuid, Handler<AsyncResult<Record>> resultHandler) {
     Objects.requireNonNull(uuid, "No registration id in the record");
     Context context = Vertx.currentContext();
-    getRecordById(context, uuid, record -> {
-      if (record == null) {
-        resultHandler.handle(Future.failedFuture("Unknown registration " + uuid));
+
+    ensureConnected(x -> {
+      if (x.failed()) {
+        resultHandler.handle(Future.failedFuture(x.cause()));
       } else {
-        try {
-          DeleteBuilder delete = client.delete();
-          if (guaranteed) {
-            delete.guaranteed();
+        getRecordById(context, uuid, record -> {
+          if (record == null) {
+            resultHandler.handle(Future.failedFuture("Unknown registration " + uuid));
+          } else {
+            try {
+              DeleteBuilder delete = client.delete();
+              if (guaranteed) {
+                delete.guaranteed();
+              }
+              delete
+                  .deletingChildrenIfNeeded()
+                  .inBackground((curatorFramework, curatorEvent)
+                      -> callback(context, record, resultHandler, curatorEvent))
+
+                  .withUnhandledErrorListener((s, throwable)
+                      -> resultHandler.handle(Future.failedFuture(throwable)))
+
+                  .forPath(getPath(uuid));
+            } catch (Exception e) {
+              resultHandler.handle(Future.failedFuture(e));
+            }
           }
-          delete
-              .deletingChildrenIfNeeded()
-              .inBackground((curatorFramework, curatorEvent)
-                  -> callback(context, record, resultHandler, curatorEvent))
-
-              .withUnhandledErrorListener((s, throwable)
-                  -> resultHandler.handle(Future.failedFuture(throwable)))
-
-              .forPath(getPath(uuid));
-        } catch (Exception e) {
-          resultHandler.handle(Future.failedFuture(e));
-        }
+        });
       }
     });
   }
 
   private void getRecordById(Context context, String uuid, Handler<Record> handler) {
-    try {
-      client.getData()
-          .inBackground((curatorFramework, curatorEvent)
-              -> runOnContextIfPossible(context, () -> {
-            if (curatorEvent.getResultCode() == KeeperException.Code.OK.intValue()) {
-              JsonObject json
-                  = new JsonObject(new String(curatorEvent.getData(), CHARSET));
-              handler.handle(new Record(json));
-            } else {
-              handler.handle(null);
-            }
-          }))
-          .forPath(getPath(uuid));
-    } catch (Exception e) {
-      handler.handle(null);
-    }
+    ensureConnected(x -> {
+      if (x.failed()) {
+        handler.handle(null);
+      } else {
+        try {
+          client.getData()
+              .inBackground((curatorFramework, curatorEvent)
+                  -> runOnContextIfPossible(context, () -> {
+                if (curatorEvent.getResultCode() == KeeperException.Code.OK.intValue()) {
+                  JsonObject json
+                      = new JsonObject(new String(curatorEvent.getData(), CHARSET));
+                  handler.handle(new Record(json));
+                } else {
+                  handler.handle(null);
+                }
+              }))
+              .forPath(getPath(uuid));
+        } catch (Exception e) {
+          handler.handle(null);
+        }
+      }
+    });
+
   }
 
   private void runOnContextIfPossible(Context context, Runnable runnable) {
@@ -151,57 +188,73 @@ public class ZookeeperBackendService implements ServiceDiscoveryBackend {
   public void update(Record record, Handler<AsyncResult<Void>> resultHandler) {
     Objects.requireNonNull(record.getRegistration(), "No registration id in the record");
     Context context = Vertx.currentContext();
-    try {
-      client.setData()
-          .inBackground((framework, event)
-              -> runOnContextIfPossible(context, () -> {
-            if (event.getResultCode() == KeeperException.Code.OK.intValue()) {
-              resultHandler.handle(Future.succeededFuture());
-            } else {
-              KeeperException.Code code = KeeperException.Code.get(event.getResultCode());
-              resultHandler.handle(Future.failedFuture(KeeperException.create(code)));
-            }
-          }))
-          .forPath(getPath(record.getRegistration()),
-              record.toJson().encode().getBytes(CHARSET));
-    } catch (Exception e) {
-      resultHandler.handle(Future.failedFuture(e));
-    }
+    ensureConnected(x -> {
+      if (x.failed()) {
+        resultHandler.handle(Future.failedFuture(x.cause()));
+      } else {
+        try {
+          client.setData()
+              .inBackground((framework, event)
+                  -> runOnContextIfPossible(context, () -> {
+                if (event.getResultCode() == KeeperException.Code.OK.intValue()) {
+                  resultHandler.handle(Future.succeededFuture());
+                } else {
+                  KeeperException.Code code = KeeperException.Code.get(event.getResultCode());
+                  resultHandler.handle(Future.failedFuture(KeeperException.create(code)));
+                }
+              }))
+              .withUnhandledErrorListener((message, e) -> resultHandler.handle(Future.failedFuture(e)))
+              .forPath(getPath(record.getRegistration()),
+                  record.toJson().encode().getBytes(CHARSET));
+        } catch (Exception e) {
+          resultHandler.handle(Future.failedFuture(e));
+        }
+      }
+    });
   }
 
   @Override
   public void getRecords(Handler<AsyncResult<List<Record>>> resultHandler) {
     Context context = Vertx.currentContext();
-    try {
-      client.getChildren()
-          .inBackground((fmk, event) -> {
-            List<String> children = event.getChildren();
-            List<Future> futures = new ArrayList<>();
-            for (String child : children) {
-              Future<Record> future = Future.future();
-              getRecord(child, future.completer());
-              futures.add(future);
-            }
-
-            CompositeFuture.all(futures)
-                .setHandler(ar -> {
-                  runOnContextIfPossible(context, () -> {
-                    if (ar.failed()) {
-                      resultHandler.handle(Future.failedFuture(ar.cause()));
-                    } else {
-                      List<Record> records = new ArrayList<>();
-                      for (Future future : futures) {
-                        records.add((Record) future.result());
-                      }
-                      resultHandler.handle(Future.succeededFuture(records));
+    ensureConnected(
+        x -> {
+          if (x.failed()) {
+            resultHandler.handle(Future.failedFuture(x.cause()));
+          } else {
+            try {
+              client.getChildren()
+                  .inBackground((fmk, event) -> {
+                    List<String> children = event.getChildren();
+                    List<Future> futures = new ArrayList<>();
+                    for (String child : children) {
+                      Future<Record> future = Future.future();
+                      getRecord(child, future.completer());
+                      futures.add(future);
                     }
-                  });
-                });
-          })
-          .forPath(basePath);
-    } catch (Exception e) {
-      resultHandler.handle(Future.failedFuture(e));
-    }
+
+                    CompositeFuture.all(futures)
+                        .setHandler(
+                            ar -> runOnContextIfPossible(context, () -> {
+                              if (ar.failed()) {
+                                resultHandler.handle(Future.failedFuture(ar.cause()));
+                              } else {
+                                List<Record> records = new ArrayList<>();
+                                for (Future future : futures) {
+                                  records.add((Record) future.result());
+                                }
+                                resultHandler.handle(Future.succeededFuture(records));
+                              }
+                            }));
+                  })
+                  .withUnhandledErrorListener((message, e) -> resultHandler.handle(Future.failedFuture(e)))
+                  .forPath(basePath);
+            } catch (Exception e) {
+              resultHandler.handle(Future.failedFuture(e));
+            }
+          }
+        }
+    );
+
   }
 
   @Override
@@ -209,25 +262,72 @@ public class ZookeeperBackendService implements ServiceDiscoveryBackend {
     Objects.requireNonNull(uuid);
     Context context = Vertx.currentContext();
 
-    try {
-      client.getData()
-          .inBackground((fmk, curatorEvent)
-              -> runOnContextIfPossible(context, () -> {
-            if (curatorEvent.getResultCode() == KeeperException.Code.OK.intValue()) {
-              JsonObject json
-                  = new JsonObject(new String(curatorEvent.getData(), CHARSET));
-              handler.handle(Future.succeededFuture(new Record(json)));
-            } else if (curatorEvent.getResultCode() == KeeperException.Code.NONODE.intValue()) {
-              handler.handle(Future.succeededFuture(null));
-            } else {
-              KeeperException.Code code = KeeperException.Code
-                  .get(curatorEvent.getResultCode());
-              handler.handle(Future.failedFuture(KeeperException.create(code)));
-            }
-          }))
-          .forPath(getPath(uuid));
-    } catch (Exception e) {
-      handler.handle(null);
+    ensureConnected(x -> {
+      if (x.failed()) {
+        handler.handle(Future.failedFuture(x.cause()));
+      } else {
+        try {
+          client.getData()
+              .inBackground((fmk, curatorEvent)
+                  -> runOnContextIfPossible(context, () -> {
+                if (curatorEvent.getResultCode() == KeeperException.Code.OK.intValue()) {
+                  JsonObject json
+                      = new JsonObject(new String(curatorEvent.getData(), CHARSET));
+                  handler.handle(Future.succeededFuture(new Record(json)));
+                } else if (curatorEvent.getResultCode() == KeeperException.Code.NONODE.intValue()) {
+                  handler.handle(Future.succeededFuture(null));
+                } else {
+                  KeeperException.Code code = KeeperException.Code.get(curatorEvent.getResultCode());
+                  handler.handle(Future.failedFuture(KeeperException.create(code)));
+                }
+              }))
+              .withUnhandledErrorListener((message, e) -> handler.handle(Future.failedFuture(e)))
+              .forPath(getPath(uuid));
+        } catch (Exception e) {
+          handler.handle(Future.failedFuture(e));
+        }
+      }
+    });
+  }
+
+  @Override
+  public synchronized void stateChanged(CuratorFramework client, ConnectionState newState) {
+    connectionState = newState;
+  }
+
+  private synchronized void ensureConnected(Handler<AsyncResult<Void>> handler) {
+    switch (connectionState) {
+      case CONNECTED:
+      case RECONNECTED:
+        handler.handle(Future.succeededFuture());
+        break;
+      case READ_ONLY:
+        if (canBeReadOnly) {
+          handler.handle(Future.succeededFuture());
+          break;
+        } // Else attempt to reconnect
+      case LOST:
+      case SUSPENDED:
+        vertx.executeBlocking(
+            future -> {
+              try {
+                if (client.blockUntilConnected(connectionTimeoutMs, TimeUnit.MILLISECONDS)) {
+                  future.complete();
+                } else {
+                  future.fail(new TimeoutException());
+                }
+              } catch (Exception e) {
+                future.fail(e);
+              }
+            }, ar -> {
+              if (ar.failed()) {
+                handler.handle(Future.failedFuture(KeeperException.create(KeeperException.Code.CONNECTIONLOSS)));
+              } else {
+                handler.handle(Future.succeededFuture());
+              }
+            });
+        break;
     }
+
   }
 }

--- a/vertx-service-discovery-backend-zookeeper/src/main/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendService.java
+++ b/vertx-service-discovery-backend-zookeeper/src/main/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendService.java
@@ -1,0 +1,233 @@
+package io.vertx.servicediscovery.backend.zookeeper;
+
+import io.vertx.core.*;
+import io.vertx.core.json.JsonObject;
+import io.vertx.servicediscovery.Record;
+import io.vertx.servicediscovery.spi.ServiceDiscoveryBackend;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.CuratorEvent;
+import org.apache.curator.framework.api.DeleteBuilder;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class ZookeeperBackendService implements ServiceDiscoveryBackend {
+
+  private static final Charset CHARSET = Charset.forName("UTF-8");
+  private CuratorFramework client;
+  private String basePath;
+  private boolean ephemeral;
+  private boolean guaranteed;
+
+  @Override
+  public void init(Vertx vertx, JsonObject configuration) {
+    String connection = Objects.requireNonNull(configuration.getString("connection"));
+    int maxRetries = configuration.getInteger("maxRetries", 3);
+    int baseGraceBetweenRetries = configuration
+        .getInteger("baseSleepTimeBetweenRetries", 1000);
+    basePath = configuration.getString("basePath", "/services");
+    ephemeral = configuration.getBoolean("ephemeral", true);
+    guaranteed = configuration.getBoolean("guaranteed", false);
+
+    client = CuratorFrameworkFactory.newClient(connection,
+        new ExponentialBackoffRetry(baseGraceBetweenRetries, maxRetries));
+    client.start();
+  }
+
+  @Override
+  public void store(Record record, Handler<AsyncResult<Record>> resultHandler) {
+    if (record.getRegistration() != null) {
+      resultHandler.handle(Future.failedFuture("The record has already been registered"));
+      return;
+    }
+    String uuid = UUID.randomUUID().toString();
+    record.setRegistration(uuid);
+
+    String content = record.toJson().encode();
+    Context context = Vertx.currentContext();
+    try {
+      client.create()
+          .creatingParentsIfNeeded()
+          .withMode(ephemeral ? CreateMode.EPHEMERAL : CreateMode.PERSISTENT)
+          .inBackground((curatorFramework, curatorEvent)
+              -> callback(context, record, resultHandler, curatorEvent))
+          .withUnhandledErrorListener((s, throwable)
+              -> resultHandler.handle(Future.failedFuture(throwable)))
+          .forPath(getPath(record.getRegistration()), content.getBytes(CHARSET));
+    } catch (Exception e) {
+      resultHandler.handle(Future.failedFuture(e));
+    }
+  }
+
+  private String getPath(String registration) {
+    return basePath + "/" + registration;
+  }
+
+  private void callback(Context context, Record record, Handler<AsyncResult<Record>> resultHandler, CuratorEvent curatorEvent) {
+    runOnContextIfPossible(context, () -> {
+      if (curatorEvent.getResultCode() == KeeperException.Code.OK.intValue()) {
+        resultHandler.handle(Future.succeededFuture(record));
+      } else {
+        KeeperException.Code code =
+            KeeperException.Code.get(curatorEvent.getResultCode());
+        resultHandler.handle(Future.failedFuture(KeeperException.create(code)));
+      }
+    });
+  }
+
+  @Override
+  public void remove(Record record, Handler<AsyncResult<Record>> resultHandler) {
+    Objects.requireNonNull(record.getRegistration(), "No registration id in the record");
+    remove(record.getRegistration(), resultHandler);
+  }
+
+  @Override
+  public void remove(String uuid, Handler<AsyncResult<Record>> resultHandler) {
+    Objects.requireNonNull(uuid, "No registration id in the record");
+    Context context = Vertx.currentContext();
+    getRecordById(context, uuid, record -> {
+      if (record == null) {
+        resultHandler.handle(Future.failedFuture("Unknown registration " + uuid));
+      } else {
+        try {
+          DeleteBuilder delete = client.delete();
+          if (guaranteed) {
+            delete.guaranteed();
+          }
+          delete
+              .deletingChildrenIfNeeded()
+              .inBackground((curatorFramework, curatorEvent)
+                  -> callback(context, record, resultHandler, curatorEvent))
+
+              .withUnhandledErrorListener((s, throwable)
+                  -> resultHandler.handle(Future.failedFuture(throwable)))
+
+              .forPath(getPath(uuid));
+        } catch (Exception e) {
+          resultHandler.handle(Future.failedFuture(e));
+        }
+      }
+    });
+  }
+
+  private void getRecordById(Context context, String uuid, Handler<Record> handler) {
+    try {
+      client.getData()
+          .inBackground((curatorFramework, curatorEvent)
+              -> runOnContextIfPossible(context, () -> {
+            if (curatorEvent.getResultCode() == KeeperException.Code.OK.intValue()) {
+              JsonObject json
+                  = new JsonObject(new String(curatorEvent.getData(), CHARSET));
+              handler.handle(new Record(json));
+            } else {
+              handler.handle(null);
+            }
+          }))
+          .forPath(getPath(uuid));
+    } catch (Exception e) {
+      handler.handle(null);
+    }
+  }
+
+  private void runOnContextIfPossible(Context context, Runnable runnable) {
+    if (context != null) {
+      context.runOnContext(v -> runnable.run());
+    } else {
+      runnable.run();
+    }
+  }
+
+  @Override
+  public void update(Record record, Handler<AsyncResult<Void>> resultHandler) {
+    Objects.requireNonNull(record.getRegistration(), "No registration id in the record");
+    Context context = Vertx.currentContext();
+    try {
+      client.setData()
+          .inBackground((framework, event)
+              -> runOnContextIfPossible(context, () -> {
+            if (event.getResultCode() == KeeperException.Code.OK.intValue()) {
+              resultHandler.handle(Future.succeededFuture());
+            } else {
+              KeeperException.Code code = KeeperException.Code.get(event.getResultCode());
+              resultHandler.handle(Future.failedFuture(KeeperException.create(code)));
+            }
+          }))
+          .forPath(getPath(record.getRegistration()),
+              record.toJson().encode().getBytes(CHARSET));
+    } catch (Exception e) {
+      resultHandler.handle(Future.failedFuture(e));
+    }
+  }
+
+  @Override
+  public void getRecords(Handler<AsyncResult<List<Record>>> resultHandler) {
+    Context context = Vertx.currentContext();
+    try {
+      client.getChildren()
+          .inBackground((fmk, event) -> {
+            List<String> children = event.getChildren();
+            List<Future> futures = new ArrayList<>();
+            for (String child : children) {
+              Future<Record> future = Future.future();
+              getRecord(child, future.completer());
+              futures.add(future);
+            }
+
+            CompositeFuture.all(futures)
+                .setHandler(ar -> {
+                  runOnContextIfPossible(context, () -> {
+                    if (ar.failed()) {
+                      resultHandler.handle(Future.failedFuture(ar.cause()));
+                    } else {
+                      List<Record> records = new ArrayList<>();
+                      for (Future future : futures) {
+                        records.add((Record) future.result());
+                      }
+                      resultHandler.handle(Future.succeededFuture(records));
+                    }
+                  });
+                });
+          })
+          .forPath(basePath);
+    } catch (Exception e) {
+      resultHandler.handle(Future.failedFuture(e));
+    }
+  }
+
+  @Override
+  public void getRecord(String uuid, Handler<AsyncResult<Record>> handler) {
+    Objects.requireNonNull(uuid);
+    Context context = Vertx.currentContext();
+
+    try {
+      client.getData()
+          .inBackground((fmk, curatorEvent)
+              -> runOnContextIfPossible(context, () -> {
+            if (curatorEvent.getResultCode() == KeeperException.Code.OK.intValue()) {
+              JsonObject json
+                  = new JsonObject(new String(curatorEvent.getData(), CHARSET));
+              handler.handle(Future.succeededFuture(new Record(json)));
+            } else if (curatorEvent.getResultCode() == KeeperException.Code.NONODE.intValue()) {
+              handler.handle(Future.succeededFuture(null));
+            } else {
+              KeeperException.Code code = KeeperException.Code
+                  .get(curatorEvent.getResultCode());
+              handler.handle(Future.failedFuture(KeeperException.create(code)));
+            }
+          }))
+          .forPath(getPath(uuid));
+    } catch (Exception e) {
+      handler.handle(null);
+    }
+  }
+}

--- a/vertx-service-discovery-backend-zookeeper/src/main/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendService.java
+++ b/vertx-service-discovery-backend-zookeeper/src/main/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendService.java
@@ -36,7 +36,7 @@ public class ZookeeperBackendService implements ServiceDiscoveryBackend {
     int baseGraceBetweenRetries = configuration
         .getInteger("baseSleepTimeBetweenRetries", 1000);
     basePath = configuration.getString("basePath", "/services");
-    ephemeral = configuration.getBoolean("ephemeral", true);
+    ephemeral = configuration.getBoolean("ephemeral", false);
     guaranteed = configuration.getBoolean("guaranteed", false);
 
     client = CuratorFrameworkFactory.newClient(connection,

--- a/vertx-service-discovery-backend-zookeeper/src/main/java/io/vertx/servicediscovery/backend/zookeeper/package-info.java
+++ b/vertx-service-discovery-backend-zookeeper/src/main/java/io/vertx/servicediscovery/backend/zookeeper/package-info.java
@@ -62,6 +62,8 @@
  * * `maxRetries`: the number of connection attempt, 3 by default
  * * `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
  * 1000 ms by default.
+ * * `connectionTimeoutMs`: the connection timeout in milliseconds. Defaults to 1000.
+ * * `canBeReadOnly` : whether or not the backend support the _read-only_ mode (defaults to false)
  * * `basePath`: the Zookeeper path in which the service records are stored. Default to `/services`.
  * * `ephemeral`: whether or not the created nodes are ephemeral nodes (see
  * https://zookeeper.apache.org/doc/r3.4.5/zookeeperOver.html#Nodes+and+ephemeral+nodes). `false` by default

--- a/vertx-service-discovery-backend-zookeeper/src/main/java/io/vertx/servicediscovery/backend/zookeeper/package-info.java
+++ b/vertx-service-discovery-backend-zookeeper/src/main/java/io/vertx/servicediscovery/backend/zookeeper/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2011-2016 The original author or authors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+/**
+ * == Vert.x Discovery Backend - Zookeeper
+ *
+ */
+@ModuleGen(name = "vertx-service-discovery-backend-zookeeper", groupPackage = "io.vertx")
+@Document(fileName = "index.adoc")
+package io.vertx.servicediscovery.backend.zookeeper;
+
+import io.vertx.codegen.annotations.ModuleGen;
+import io.vertx.docgen.Document;

--- a/vertx-service-discovery-backend-zookeeper/src/main/java/io/vertx/servicediscovery/backend/zookeeper/package-info.java
+++ b/vertx-service-discovery-backend-zookeeper/src/main/java/io/vertx/servicediscovery/backend/zookeeper/package-info.java
@@ -17,6 +17,73 @@
 /**
  * == Vert.x Discovery Backend - Zookeeper
  *
+ * The service discovery has a plug-able backend using the {@link io.vertx.servicediscovery.spi.ServiceDiscoveryBackend} SPI. This is an implementation of the SPI based
+ * on Apache Zookeeper.
+ *
+ * == Using the Zookeeper backend
+ *
+ * To use the Zookeeper backend, add the following dependency to the _dependencies_ section of your build
+ * descriptor:
+ *
+ * * Maven (in your `pom.xml`):
+ *
+ * [source,xml,subs="+attributes"]
+ * ----
+ * <dependency>
+ *   <groupId>${maven.groupId}</groupId>
+ *   <artifactId>${maven.artifactId}</artifactId>
+ *   <version>${maven.version}</version>
+ * </dependency>
+ * ----
+ *
+ * * Gradle (in your `build.gradle` file):
+ *
+ * [source,groovy,subs="+attributes"]
+ * ----
+ * compile '${maven.groupId}:${maven.artifactId}:${maven.version}'
+ * ----
+ *
+ * Be aware that you can have only a single implementation of the SPI in your _classpath_. If none,
+ * the default backend is used.
+ *
+ * == Configuration
+ *
+ * There is a single mandatory configuration attribute: `connection`. Connection is the Zookeeper connection _string_.
+ *
+ * Here is an example:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.Examples#configuration1(io.vertx.core.Vertx)}
+ * ----
+ *
+ * Additionally you can configure:
+ *
+ * * `maxRetries`: the number of connection attempt, 3 by default
+ * * `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
+ * 1000 ms by default.
+ * * `basePath`: the Zookeeper path in which the service records are stored. Default to `/services`.
+ * * `ephemeral`: whether or not the created nodes are ephemeral nodes (see
+ * https://zookeeper.apache.org/doc/r3.4.5/zookeeperOver.html#Nodes+and+ephemeral+nodes). `false` by default
+ * * `guaranteed`: whether or not to guarantee the node deletion even in case of failure. `false` by default
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.Examples#configuration2(io.vertx.core.Vertx)}
+ * ----
+ *
+ * == How are stored the records
+ *
+ * The records are stored in individual nodes structured as follows:
+ *
+ * [source]
+ * ----
+ * basepath (/services/)
+ *    |
+ *    |- record 1 registration id => the record 1 is the data of this node
+ *    |- record 2 registration id => the record 2 is the data of this node
+ * ----
+ *
  */
 @ModuleGen(name = "vertx-service-discovery-backend-zookeeper", groupPackage = "io.vertx")
 @Document(fileName = "index.adoc")

--- a/vertx-service-discovery-backend-zookeeper/src/main/resources/META-INF/services/io.vertx.servicediscovery.spi.ServiceDiscoveryBackend
+++ b/vertx-service-discovery-backend-zookeeper/src/main/resources/META-INF/services/io.vertx.servicediscovery.spi.ServiceDiscoveryBackend
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2011-2016 The original author or authors
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# and Apache License v2.0 which accompanies this distribution.
+#
+#      The Eclipse Public License is available at
+#      http://www.eclipse.org/legal/epl-v10.html
+#
+#      The Apache License v2.0 is available at
+#      http://www.opensource.org/licenses/apache2.0.php
+#
+# You may elect to redistribute this code under either of these licenses.
+#
+
+io.vertx.servicediscovery.backend.zookeeper.ZookeeperBackendService

--- a/vertx-service-discovery-backend-zookeeper/src/test/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendServiceTest.java
+++ b/vertx-service-discovery-backend-zookeeper/src/test/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendServiceTest.java
@@ -1,0 +1,153 @@
+package io.vertx.servicediscovery.backend.zookeeper;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.servicediscovery.Record;
+import io.vertx.servicediscovery.Status;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
+import org.junit.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class ZookeeperBackendServiceTest {
+
+  private static final Integer DEFAULT_PORT = 2181;
+  private static TestingServer server;
+
+  private static final Map<Integer, TestingServer> instances = new ConcurrentHashMap<>();
+
+  protected ZookeeperBackendService backend;
+  protected Vertx vertx;
+
+  @BeforeClass
+  public static void startZookeeper() throws Exception {
+    server = new TestingServer(DEFAULT_PORT);
+    server.start();
+  }
+
+  @AfterClass
+  public static void stopZookeeper() throws IOException {
+    server.stop();
+  }
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+    backend = new ZookeeperBackendService();
+    backend.init(vertx, new JsonObject().put("connection",
+        server.getConnectString()));
+  }
+
+  @After
+  public void tearDown() {
+    AtomicBoolean completed = new AtomicBoolean();
+    vertx.close(ar -> completed.set(ar.succeeded()));
+    await().untilAtomic(completed, is(true));
+  }
+
+  @Test
+  public void testInsertion() {
+    Record record = new Record().setName("my-service").setStatus(Status.UP);
+    assertThat(record.getRegistration()).isNull();
+
+    // Insertion
+    AtomicReference<Record> reference = new AtomicReference<>();
+    backend.store(record, ar -> {
+      if (!ar.succeeded()) {
+        ar.cause().printStackTrace();
+      }
+      reference.set(ar.result());
+    });
+
+    await().until(() -> reference.get() != null);
+    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
+    assertThat(reference.get().getRegistration()).isNotNull();
+    record = reference.get();
+
+    // Retrieve
+    reference.set(null);
+    backend.getRecord(record.getRegistration(), ar -> reference.set(ar.result()));
+    await().until(() -> reference.get() != null);
+    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
+    assertThat(reference.get().getRegistration()).isNotNull();
+
+    // Remove
+    AtomicBoolean completed = new AtomicBoolean();
+    backend.remove(record, ar -> {
+      completed.set(ar.succeeded());
+    });
+    await().untilAtomic(completed, is(true));
+
+    // Retrieve
+    completed.set(false);
+    reference.set(null);
+    backend.getRecord(record.getRegistration(), ar -> {
+      if (!ar.succeeded()) {
+        ar.cause().printStackTrace();
+      }
+      completed.set(ar.succeeded());
+      reference.set(ar.result());
+    });
+
+    await().untilAtomic(completed, is(true));
+    assertThat(reference.get()).isNull();
+  }
+
+  @Test
+  public void testInsertionOfMultipleRecords() {
+    Record record1 = new Record().setName("my-service-1").setStatus(Status.UP);
+    assertThat(record1.getRegistration()).isNull();
+    Record record2 = new Record().setName("my-service-2").setStatus(Status.UP);
+    assertThat(record2.getRegistration()).isNull();
+    Record record3 = new Record().setName("my-service-3").setStatus(Status.UP);
+    assertThat(record3.getRegistration()).isNull();
+
+    // Insertion
+    AtomicBoolean completed = new AtomicBoolean();
+    backend.store(record1, ar -> {
+          backend.store(record2, ar2 -> {
+            backend.store(record3, ar3 -> {
+              completed.set(ar3.succeeded());
+            });
+          });
+        }
+    );
+
+    await().untilAtomic(completed, is(true));
+
+    List<Record> records = new ArrayList<>();
+    // Get records
+    backend.getRecords(ar -> {
+      records.addAll(ar.result());
+    });
+    await().until(() -> !records.isEmpty());
+
+    assertThat(records).hasSize(3);
+
+    // Get each records
+    for (Record record : records) {
+      AtomicReference<Record> retrieved = new AtomicReference<>();
+      backend.getRecord(record.getRegistration(), ar -> retrieved.set(ar.result()));
+      await().untilAtomic(retrieved, not(nullValue()));
+    }
+  }
+
+}

--- a/vertx-service-discovery-backend-zookeeper/src/test/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendServiceTest.java
+++ b/vertx-service-discovery-backend-zookeeper/src/test/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendServiceTest.java
@@ -1,13 +1,26 @@
 package io.vertx.servicediscovery.backend.zookeeper;
 
 import io.vertx.core.json.JsonObject;
+import io.vertx.servicediscovery.Record;
+import io.vertx.servicediscovery.Status;
 import io.vertx.servicediscovery.spi.ServiceDiscoveryBackend;
 import io.vertx.servicediscovery.spi.ServiceDiscoveryBackendTest;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.KeeperException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.core.Is.is;
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
@@ -31,8 +44,82 @@ public class ZookeeperBackendServiceTest extends ServiceDiscoveryBackendTest {
   @Override
   protected ServiceDiscoveryBackend createBackend() {
     ZookeeperBackendService backend = new ZookeeperBackendService();
-    backend.init(vertx, new JsonObject().put("connection",
-        server.getConnectString()));
+    backend.init(vertx, new JsonObject()
+        .put("connection",  server.getConnectString())
+        .put("baseSleepTimeBetweenRetries",  10)
+        .put("connectionTimeoutMs",  1000));
     return backend;
+  }
+
+  @Test
+  public void testReconnection() throws Exception {
+    Record record = new Record().setName("my-service").setStatus(Status.UP);
+    assertThat(record.getRegistration()).isNull();
+
+    // Insertion
+    AtomicReference<Record> reference = new AtomicReference<>();
+    backend.store(record, ar -> {
+      if (!ar.succeeded()) {
+        ar.cause().printStackTrace();
+      }
+      reference.set(ar.result());
+    });
+
+    await().until(() -> reference.get() != null);
+    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
+    assertThat(reference.get().getRegistration()).isNotNull();
+    record = reference.get();
+
+    // Retrieve
+    reference.set(null);
+    backend.getRecord(record.getRegistration(), ar -> reference.set(ar.result()));
+    await().until(() -> reference.get() != null);
+    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
+    assertThat(reference.get().getRegistration()).isNotNull();
+
+    server.stop();
+
+    AtomicReference<Throwable> error = new AtomicReference<>();
+    backend.getRecord(record.getRegistration(), ar -> error.set(ar.cause()));
+    await().until(() -> error.get() != null);
+    assertThat(error.get()).isInstanceOf(KeeperException.ConnectionLossException.class);
+
+    server.restart();
+    CuratorFramework client = CuratorFrameworkFactory.builder()
+        .connectString(server.getConnectString())
+        .retryPolicy(new ExponentialBackoffRetry(10, 3))
+        .build();
+    client.start();
+    // Wait until we have been connected to the server
+    client.blockUntilConnected();
+
+    reference.set(null);
+    backend.getRecord(record.getRegistration(), ar -> {
+      if (ar.failed()) {
+        ar.cause().printStackTrace();
+      }
+      reference.set(ar.result());
+    });
+
+
+    await().until(() -> reference.get() != null);
+    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
+    assertThat(reference.get().getRegistration()).isNotNull();
+
+    server.stop();
+
+    // Remove
+    AtomicBoolean completed = new AtomicBoolean();
+    completed.set(false);
+    backend.remove(record, ar -> completed.set(ar.failed()));
+    await().untilAtomic(completed, is(true));
+
+    server.restart();
+
+    completed.set(false);
+    backend.remove(record, ar -> completed.set(ar.succeeded()));
+    await().untilAtomic(completed, is(true));
+
+    client.close();
   }
 }

--- a/vertx-service-discovery-backend-zookeeper/src/test/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendServiceTest.java
+++ b/vertx-service-discovery-backend-zookeeper/src/test/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendServiceTest.java
@@ -150,4 +150,69 @@ public class ZookeeperBackendServiceTest {
     }
   }
 
+  @Test
+  public void testInsertionFollowedByAnUpdate() {
+    Record record = new Record().setName("my-service").setStatus(Status.UP);
+    assertThat(record.getRegistration()).isNull();
+
+    // Insertion
+    AtomicReference<Record> reference = new AtomicReference<>();
+    backend.store(record, ar -> {
+      if (!ar.succeeded()) {
+        ar.cause().printStackTrace();
+      }
+      reference.set(ar.result());
+    });
+
+    await().until(() -> reference.get() != null);
+    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
+    assertThat(reference.get().getRegistration()).isNotNull();
+    record = reference.get();
+
+    // Retrieve
+    reference.set(null);
+    backend.getRecord(record.getRegistration(), ar -> reference.set(ar.result()));
+    await().until(() -> reference.get() != null);
+    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
+    assertThat(reference.get().getRegistration()).isNotNull();
+
+    // Update
+    AtomicBoolean completed = new AtomicBoolean();
+    record.getMetadata().put("some-new-key", "some-new-value");
+    backend.update(record, ar -> {
+      completed.set(ar.succeeded());
+    });
+    await().untilAtomic(completed, is(true));
+
+    // Retrieve
+    reference.set(null);
+    backend.getRecord(record.getRegistration(), ar -> reference.set(ar.result()));
+    await().until(() -> reference.get() != null);
+    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
+    assertThat(reference.get().getMetadata().getString("some-new-key"))
+        .isEqualToIgnoringCase("some-new-value");
+    assertThat(reference.get().getRegistration()).isNotNull();
+
+    // Remove
+    completed.set(false);
+    backend.remove(record, ar -> {
+      completed.set(ar.succeeded());
+    });
+    await().untilAtomic(completed, is(true));
+
+    // Retrieve
+    completed.set(false);
+    reference.set(null);
+    backend.getRecord(record.getRegistration(), ar -> {
+      if (!ar.succeeded()) {
+        ar.cause().printStackTrace();
+      }
+      completed.set(ar.succeeded());
+      reference.set(ar.result());
+    });
+
+    await().untilAtomic(completed, is(true));
+    assertThat(reference.get()).isNull();
+  }
+
 }

--- a/vertx-service-discovery-backend-zookeeper/src/test/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendServiceTest.java
+++ b/vertx-service-discovery-backend-zookeeper/src/test/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendServiceTest.java
@@ -1,41 +1,21 @@
 package io.vertx.servicediscovery.backend.zookeeper;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import io.vertx.servicediscovery.Record;
-import io.vertx.servicediscovery.Status;
-import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.retry.RetryOneTime;
+import io.vertx.servicediscovery.spi.ServiceDiscoveryBackend;
+import io.vertx.servicediscovery.spi.ServiceDiscoveryBackendTest;
 import org.apache.curator.test.TestingServer;
-import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
-import org.junit.*;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static com.jayway.awaitility.Awaitility.await;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
  */
-public class ZookeeperBackendServiceTest {
+public class ZookeeperBackendServiceTest extends ServiceDiscoveryBackendTest {
 
   private static final Integer DEFAULT_PORT = 2181;
   private static TestingServer server;
-
-  private static final Map<Integer, TestingServer> instances = new ConcurrentHashMap<>();
-
-  protected ZookeeperBackendService backend;
-  protected Vertx vertx;
 
   @BeforeClass
   public static void startZookeeper() throws Exception {
@@ -48,171 +28,11 @@ public class ZookeeperBackendServiceTest {
     server.stop();
   }
 
-  @Before
-  public void setUp() {
-    vertx = Vertx.vertx();
-    backend = new ZookeeperBackendService();
+  @Override
+  protected ServiceDiscoveryBackend createBackend() {
+    ZookeeperBackendService backend = new ZookeeperBackendService();
     backend.init(vertx, new JsonObject().put("connection",
         server.getConnectString()));
+    return backend;
   }
-
-  @After
-  public void tearDown() {
-    AtomicBoolean completed = new AtomicBoolean();
-    vertx.close(ar -> completed.set(ar.succeeded()));
-    await().untilAtomic(completed, is(true));
-  }
-
-  @Test
-  public void testInsertion() {
-    Record record = new Record().setName("my-service").setStatus(Status.UP);
-    assertThat(record.getRegistration()).isNull();
-
-    // Insertion
-    AtomicReference<Record> reference = new AtomicReference<>();
-    backend.store(record, ar -> {
-      if (!ar.succeeded()) {
-        ar.cause().printStackTrace();
-      }
-      reference.set(ar.result());
-    });
-
-    await().until(() -> reference.get() != null);
-    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
-    assertThat(reference.get().getRegistration()).isNotNull();
-    record = reference.get();
-
-    // Retrieve
-    reference.set(null);
-    backend.getRecord(record.getRegistration(), ar -> reference.set(ar.result()));
-    await().until(() -> reference.get() != null);
-    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
-    assertThat(reference.get().getRegistration()).isNotNull();
-
-    // Remove
-    AtomicBoolean completed = new AtomicBoolean();
-    backend.remove(record, ar -> {
-      completed.set(ar.succeeded());
-    });
-    await().untilAtomic(completed, is(true));
-
-    // Retrieve
-    completed.set(false);
-    reference.set(null);
-    backend.getRecord(record.getRegistration(), ar -> {
-      if (!ar.succeeded()) {
-        ar.cause().printStackTrace();
-      }
-      completed.set(ar.succeeded());
-      reference.set(ar.result());
-    });
-
-    await().untilAtomic(completed, is(true));
-    assertThat(reference.get()).isNull();
-  }
-
-  @Test
-  public void testInsertionOfMultipleRecords() {
-    Record record1 = new Record().setName("my-service-1").setStatus(Status.UP);
-    assertThat(record1.getRegistration()).isNull();
-    Record record2 = new Record().setName("my-service-2").setStatus(Status.UP);
-    assertThat(record2.getRegistration()).isNull();
-    Record record3 = new Record().setName("my-service-3").setStatus(Status.UP);
-    assertThat(record3.getRegistration()).isNull();
-
-    // Insertion
-    AtomicBoolean completed = new AtomicBoolean();
-    backend.store(record1, ar -> {
-          backend.store(record2, ar2 -> {
-            backend.store(record3, ar3 -> {
-              completed.set(ar3.succeeded());
-            });
-          });
-        }
-    );
-
-    await().untilAtomic(completed, is(true));
-
-    List<Record> records = new ArrayList<>();
-    // Get records
-    backend.getRecords(ar -> {
-      records.addAll(ar.result());
-    });
-    await().until(() -> !records.isEmpty());
-
-    assertThat(records).hasSize(3);
-
-    // Get each records
-    for (Record record : records) {
-      AtomicReference<Record> retrieved = new AtomicReference<>();
-      backend.getRecord(record.getRegistration(), ar -> retrieved.set(ar.result()));
-      await().untilAtomic(retrieved, not(nullValue()));
-    }
-  }
-
-  @Test
-  public void testInsertionFollowedByAnUpdate() {
-    Record record = new Record().setName("my-service").setStatus(Status.UP);
-    assertThat(record.getRegistration()).isNull();
-
-    // Insertion
-    AtomicReference<Record> reference = new AtomicReference<>();
-    backend.store(record, ar -> {
-      if (!ar.succeeded()) {
-        ar.cause().printStackTrace();
-      }
-      reference.set(ar.result());
-    });
-
-    await().until(() -> reference.get() != null);
-    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
-    assertThat(reference.get().getRegistration()).isNotNull();
-    record = reference.get();
-
-    // Retrieve
-    reference.set(null);
-    backend.getRecord(record.getRegistration(), ar -> reference.set(ar.result()));
-    await().until(() -> reference.get() != null);
-    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
-    assertThat(reference.get().getRegistration()).isNotNull();
-
-    // Update
-    AtomicBoolean completed = new AtomicBoolean();
-    record.getMetadata().put("some-new-key", "some-new-value");
-    backend.update(record, ar -> {
-      completed.set(ar.succeeded());
-    });
-    await().untilAtomic(completed, is(true));
-
-    // Retrieve
-    reference.set(null);
-    backend.getRecord(record.getRegistration(), ar -> reference.set(ar.result()));
-    await().until(() -> reference.get() != null);
-    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
-    assertThat(reference.get().getMetadata().getString("some-new-key"))
-        .isEqualToIgnoringCase("some-new-value");
-    assertThat(reference.get().getRegistration()).isNotNull();
-
-    // Remove
-    completed.set(false);
-    backend.remove(record, ar -> {
-      completed.set(ar.succeeded());
-    });
-    await().untilAtomic(completed, is(true));
-
-    // Retrieve
-    completed.set(false);
-    reference.set(null);
-    backend.getRecord(record.getRegistration(), ar -> {
-      if (!ar.succeeded()) {
-        ar.cause().printStackTrace();
-      }
-      completed.set(ar.succeeded());
-      reference.set(ar.result());
-    });
-
-    await().untilAtomic(completed, is(true));
-    assertThat(reference.get()).isNull();
-  }
-
 }

--- a/vertx-service-discovery-backend-zookeeper/src/test/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendServiceWithEphemeralAndGuaranteedTest.java
+++ b/vertx-service-discovery-backend-zookeeper/src/test/java/io/vertx/servicediscovery/backend/zookeeper/ZookeeperBackendServiceWithEphemeralAndGuaranteedTest.java
@@ -1,0 +1,42 @@
+package io.vertx.servicediscovery.backend.zookeeper;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.servicediscovery.spi.ServiceDiscoveryBackend;
+import io.vertx.servicediscovery.spi.ServiceDiscoveryBackendTest;
+import org.apache.curator.test.TestingServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class ZookeeperBackendServiceWithEphemeralAndGuaranteedTest extends ServiceDiscoveryBackendTest {
+
+  private static final Integer DEFAULT_PORT = 2181;
+  private static TestingServer server;
+
+  @BeforeClass
+  public static void startZookeeper() throws Exception {
+    server = new TestingServer(DEFAULT_PORT);
+    server.start();
+  }
+
+  @AfterClass
+  public static void stopZookeeper() throws IOException {
+    server.stop();
+  }
+
+  @Override
+  protected ServiceDiscoveryBackend createBackend() {
+    ZookeeperBackendService backend = new ZookeeperBackendService();
+    backend.init(vertx, new JsonObject()
+        .put("connection", server.getConnectString())
+        .put("ephemeral", true)
+        .put("guaranteed", true)
+        .put("basePath", "/services/my-backend")
+    );
+    return backend;
+  }
+}

--- a/vertx-service-discovery-bridge-zookeeper/pom.xml
+++ b/vertx-service-discovery-bridge-zookeeper/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.vertx</groupId>
+    <artifactId>vertx-service-discovery-parent</artifactId>
+    <version>3.4.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>vertx-service-discovery-bridge-zookeeper</artifactId>
+
+  <properties>
+    <curator.version>2.11.0</curator.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-service-discovery</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-framework</artifactId>
+      <version>${curator.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-x-discovery</artifactId>
+      <version>${curator.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
+      <version>${curator.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.revelc.code</groupId>
+        <artifactId>zookeeper-maven-plugin</artifactId>
+        <version>1.0.1</version>
+        <configuration>
+          <shutdownString>zk-unit-test</shutdownString>
+          <shutdownPort>21122</shutdownPort>
+          <clientPort>21123</clientPort>
+        </configuration>
+        <executions>
+          <execution>
+            <id>run-zookeeper</id>
+            <goals>
+              <goal>start</goal><!-- runs at pre-integration-test phase -->
+              <goal>stop</goal><!-- runs at post-integration-test phase -->
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.17</version>
+        <executions>
+          <execution>
+            <!-- configure failsafe to execute some ITs which use ZooKeeper -->
+            <id>run-integration-tests</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/groovy/index.adoc
@@ -1,0 +1,64 @@
+= Vert.x Discovery Bridge - Zookeeper
+
+This discovery bridge imports services from https://zookeeper.apache.org/[Apache Zookeeper] into the Vert.x service
+discovery.
+
+The bridge uses the http://curator.apache.org/curator-x-discovery/[Curator extension for service discovery].
+
+Service description are read as JSON Object (merged in the Vert.x service record metadata). The service type is
+deduced from this description by reading the `service-type`.
+
+== Using the bridge
+
+To use this Vert.x discovery bridge, add the following dependency to the _dependencies_ section of your build
+descriptor:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>io.vertx</groupId>
+  <artifactId>vertx-service-discovery-bridge-zookeeper</artifactId>
+  <version>3.4.0-SNAPSHOT</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile 'io.vertx:vertx-service-discovery-bridge-zookeeper:3.4.0-SNAPSHOT'
+----
+
+Then, when creating the service discovery registers this bridge as follows:
+
+[source, groovy]
+----
+import io.vertx.groovy.servicediscovery.ServiceDiscovery
+ServiceDiscovery.create(vertx).registerServiceImporter(new io.vertx.servicediscovery.zookeeper.ZookeeperServiceImporter(), [
+  connection:"127.0.0.1:2181"
+])
+
+----
+
+Only the `connection` configuration is mandatory. It's the connection _string_ of the Zookeeper server.
+
+In addition you can configure:
+
+* `maxRetries`: the number of connection attempt, 3 by default
+* `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
+1000 ms by default.
+* `basePath`: the Zookeeper path in which the service are stored. Default to `/discovery`.
+
+[source,groovy]
+----
+import io.vertx.groovy.servicediscovery.ServiceDiscovery
+ServiceDiscovery.create(vertx).registerServiceImporter(new io.vertx.servicediscovery.zookeeper.ZookeeperServiceImporter(), [
+  connection:"127.0.0.1:2181",
+  maxRetries:5,
+  baseSleepTimeBetweenRetries:2000,
+  basePath:"/services"
+])
+
+----

--- a/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/groovy/index.adoc
@@ -50,6 +50,8 @@ In addition you can configure:
 * `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
 1000 ms by default.
 * `basePath`: the Zookeeper path in which the service are stored. Default to `/discovery`.
+* `connectionTimeoutMs`: the connection timeout in milliseconds. Defaults to 1000.
+* `canBeReadOnly` : whether or not the backend support the _read-only_ mode (defaults to true)
 
 [source,groovy]
 ----

--- a/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/java/index.adoc
+++ b/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/java/index.adoc
@@ -1,0 +1,63 @@
+= Vert.x Discovery Bridge - Zookeeper
+
+This discovery bridge imports services from https://zookeeper.apache.org/[Apache Zookeeper] into the Vert.x service
+discovery.
+
+The bridge uses the http://curator.apache.org/curator-x-discovery/[Curator extension for service discovery].
+
+Service description are read as JSON Object (merged in the Vert.x service record metadata). The service type is
+deduced from this description by reading the `service-type`.
+
+== Using the bridge
+
+To use this Vert.x discovery bridge, add the following dependency to the _dependencies_ section of your build
+descriptor:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>io.vertx</groupId>
+  <artifactId>vertx-service-discovery-bridge-zookeeper</artifactId>
+  <version>3.4.0-SNAPSHOT</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile 'io.vertx:vertx-service-discovery-bridge-zookeeper:3.4.0-SNAPSHOT'
+----
+
+Then, when creating the service discovery registers this bridge as follows:
+
+[source, java]
+----
+ServiceDiscovery.create(vertx)
+    .registerServiceImporter(new ZookeeperServiceImporter(),
+        new JsonObject()
+            .put("connection", "127.0.0.1:2181"));
+----
+
+Only the `connection` configuration is mandatory. It's the connection _string_ of the Zookeeper server.
+
+In addition you can configure:
+
+* `maxRetries`: the number of connection attempt, 3 by default
+* `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
+1000 ms by default.
+* `basePath`: the Zookeeper path in which the service are stored. Default to `/discovery`.
+
+[source,java]
+----
+ServiceDiscovery.create(vertx)
+    .registerServiceImporter(new ZookeeperServiceImporter(),
+        new JsonObject()
+            .put("connection", "127.0.0.1:2181")
+            .put("maxRetries", 5)
+            .put("baseSleepTimeBetweenRetries", 2000)
+            .put("basePath", "/services")
+    );
+----

--- a/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/java/index.adoc
+++ b/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/java/index.adoc
@@ -49,6 +49,8 @@ In addition you can configure:
 * `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
 1000 ms by default.
 * `basePath`: the Zookeeper path in which the service are stored. Default to `/discovery`.
+* `connectionTimeoutMs`: the connection timeout in milliseconds. Defaults to 1000.
+* `canBeReadOnly` : whether or not the backend support the _read-only_ mode (defaults to true)
 
 [source,java]
 ----

--- a/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/js/index.adoc
+++ b/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/js/index.adoc
@@ -1,0 +1,64 @@
+= Vert.x Discovery Bridge - Zookeeper
+
+This discovery bridge imports services from https://zookeeper.apache.org/[Apache Zookeeper] into the Vert.x service
+discovery.
+
+The bridge uses the http://curator.apache.org/curator-x-discovery/[Curator extension for service discovery].
+
+Service description are read as JSON Object (merged in the Vert.x service record metadata). The service type is
+deduced from this description by reading the `service-type`.
+
+== Using the bridge
+
+To use this Vert.x discovery bridge, add the following dependency to the _dependencies_ section of your build
+descriptor:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>io.vertx</groupId>
+  <artifactId>vertx-service-discovery-bridge-zookeeper</artifactId>
+  <version>3.4.0-SNAPSHOT</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile 'io.vertx:vertx-service-discovery-bridge-zookeeper:3.4.0-SNAPSHOT'
+----
+
+Then, when creating the service discovery registers this bridge as follows:
+
+[source, js]
+----
+var ServiceDiscovery = require("vertx-service-discovery-js/service_discovery");
+ServiceDiscovery.create(vertx).registerServiceImporter(new (Java.type("io.vertx.servicediscovery.zookeeper.ZookeeperServiceImporter"))(), {
+  "connection" : "127.0.0.1:2181"
+});
+
+----
+
+Only the `connection` configuration is mandatory. It's the connection _string_ of the Zookeeper server.
+
+In addition you can configure:
+
+* `maxRetries`: the number of connection attempt, 3 by default
+* `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
+1000 ms by default.
+* `basePath`: the Zookeeper path in which the service are stored. Default to `/discovery`.
+
+[source,js]
+----
+var ServiceDiscovery = require("vertx-service-discovery-js/service_discovery");
+ServiceDiscovery.create(vertx).registerServiceImporter(new (Java.type("io.vertx.servicediscovery.zookeeper.ZookeeperServiceImporter"))(), {
+  "connection" : "127.0.0.1:2181",
+  "maxRetries" : 5,
+  "baseSleepTimeBetweenRetries" : 2000,
+  "basePath" : "/services"
+});
+
+----

--- a/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/js/index.adoc
+++ b/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/js/index.adoc
@@ -50,6 +50,8 @@ In addition you can configure:
 * `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
 1000 ms by default.
 * `basePath`: the Zookeeper path in which the service are stored. Default to `/discovery`.
+* `connectionTimeoutMs`: the connection timeout in milliseconds. Defaults to 1000.
+* `canBeReadOnly` : whether or not the backend support the _read-only_ mode (defaults to true)
 
 [source,js]
 ----

--- a/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/ruby/index.adoc
@@ -50,6 +50,8 @@ In addition you can configure:
 * `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
 1000 ms by default.
 * `basePath`: the Zookeeper path in which the service are stored. Default to `/discovery`.
+* `connectionTimeoutMs`: the connection timeout in milliseconds. Defaults to 1000.
+* `canBeReadOnly` : whether or not the backend support the _read-only_ mode (defaults to true)
 
 [source,ruby]
 ----

--- a/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-service-discovery-bridge-zookeeper/src/main/asciidoc/ruby/index.adoc
@@ -1,0 +1,64 @@
+= Vert.x Discovery Bridge - Zookeeper
+
+This discovery bridge imports services from https://zookeeper.apache.org/[Apache Zookeeper] into the Vert.x service
+discovery.
+
+The bridge uses the http://curator.apache.org/curator-x-discovery/[Curator extension for service discovery].
+
+Service description are read as JSON Object (merged in the Vert.x service record metadata). The service type is
+deduced from this description by reading the `service-type`.
+
+== Using the bridge
+
+To use this Vert.x discovery bridge, add the following dependency to the _dependencies_ section of your build
+descriptor:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>io.vertx</groupId>
+  <artifactId>vertx-service-discovery-bridge-zookeeper</artifactId>
+  <version>3.4.0-SNAPSHOT</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile 'io.vertx:vertx-service-discovery-bridge-zookeeper:3.4.0-SNAPSHOT'
+----
+
+Then, when creating the service discovery registers this bridge as follows:
+
+[source, ruby]
+----
+require 'vertx-service-discovery/service_discovery'
+VertxServiceDiscovery::ServiceDiscovery.create(vertx).register_service_importer(Java::IoVertxServicediscoveryZookeeper::ZookeeperServiceImporter.new(), {
+  'connection' => "127.0.0.1:2181"
+})
+
+----
+
+Only the `connection` configuration is mandatory. It's the connection _string_ of the Zookeeper server.
+
+In addition you can configure:
+
+* `maxRetries`: the number of connection attempt, 3 by default
+* `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
+1000 ms by default.
+* `basePath`: the Zookeeper path in which the service are stored. Default to `/discovery`.
+
+[source,ruby]
+----
+require 'vertx-service-discovery/service_discovery'
+VertxServiceDiscovery::ServiceDiscovery.create(vertx).register_service_importer(Java::IoVertxServicediscoveryZookeeper::ZookeeperServiceImporter.new(), {
+  'connection' => "127.0.0.1:2181",
+  'maxRetries' => 5,
+  'baseSleepTimeBetweenRetries' => 2000,
+  'basePath' => "/services"
+})
+
+----

--- a/vertx-service-discovery-bridge-zookeeper/src/main/java/examples/Examples.java
+++ b/vertx-service-discovery-bridge-zookeeper/src/main/java/examples/Examples.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2011-2016 The original author or authors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package examples;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.servicediscovery.ServiceDiscovery;
+import io.vertx.servicediscovery.zookeeper.ZookeeperServiceImporter;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class Examples {
+
+  public void register(Vertx vertx) {
+    ServiceDiscovery.create(vertx)
+        .registerServiceImporter(new ZookeeperServiceImporter(),
+            new JsonObject()
+                .put("connection", "127.0.0.1:2181"));
+  }
+
+
+  public void register2(Vertx vertx) {
+    ServiceDiscovery.create(vertx)
+        .registerServiceImporter(new ZookeeperServiceImporter(),
+            new JsonObject()
+                .put("connection", "127.0.0.1:2181")
+                .put("maxRetries", 5)
+                .put("baseSleepTimeBetweenRetries", 2000)
+                .put("basePath", "/services")
+        );
+  }
+}

--- a/vertx-service-discovery-bridge-zookeeper/src/main/java/examples/package-info.java
+++ b/vertx-service-discovery-bridge-zookeeper/src/main/java/examples/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2011-2016 The original author or authors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+@Source
+package examples;
+
+import io.vertx.docgen.Source;

--- a/vertx-service-discovery-bridge-zookeeper/src/main/java/io/vertx/servicediscovery/zookeeper/JsonObjectSerializer.java
+++ b/vertx-service-discovery-bridge-zookeeper/src/main/java/io/vertx/servicediscovery/zookeeper/JsonObjectSerializer.java
@@ -1,0 +1,54 @@
+package io.vertx.servicediscovery.zookeeper;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.apache.curator.x.discovery.ServiceInstanceBuilder;
+import org.apache.curator.x.discovery.details.InstanceSerializer;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class JsonObjectSerializer implements InstanceSerializer<JsonObject> {
+
+  private final ObjectMapper mapper = Json.mapper;
+  private final JavaType type;
+
+  public JsonObjectSerializer() {
+    this.type = this.mapper.getTypeFactory().constructType(ServiceInstance.class);
+  }
+
+  @Override
+  public byte[] serialize(ServiceInstance<JsonObject> instance) throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    this.mapper.writeValue(out, instance);
+    return out.toByteArray();
+  }
+
+  public ServiceInstance<JsonObject> deserialize(byte[] bytes) throws Exception {
+    ServiceInstance rawServiceInstance = this.mapper.readValue(bytes, this.type);
+    ServiceInstanceBuilder<JsonObject> builder = ServiceInstance.<JsonObject>builder()
+        .address(rawServiceInstance.getAddress())
+        .id(rawServiceInstance.getId())
+        .name(rawServiceInstance.getName())
+        .payload(new JsonObject(rawServiceInstance.getPayload().toString()))
+        .registrationTimeUTC(rawServiceInstance.getRegistrationTimeUTC())
+        .serviceType(rawServiceInstance.getServiceType());
+
+    if (rawServiceInstance.getSslPort() != null) {
+      builder.sslPort(rawServiceInstance.getSslPort());
+    }
+    if (rawServiceInstance.getPort() != null) {
+      builder.sslPort(rawServiceInstance.getPort());
+    }
+    if (rawServiceInstance.getUriSpec() != null) {
+      builder.uriSpec(rawServiceInstance.getUriSpec());
+    }
+    return builder.build();
+  }
+}
+

--- a/vertx-service-discovery-bridge-zookeeper/src/main/java/io/vertx/servicediscovery/zookeeper/RegistrationHolder.java
+++ b/vertx-service-discovery-bridge-zookeeper/src/main/java/io/vertx/servicediscovery/zookeeper/RegistrationHolder.java
@@ -1,0 +1,65 @@
+package io.vertx.servicediscovery.zookeeper;
+
+import io.vertx.servicediscovery.Record;
+import org.apache.curator.x.discovery.ServiceInstance;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+class RegistrationHolder<T> {
+
+  private final T svc;
+  private final Record record;
+
+  RegistrationHolder(Record record, T svc) {
+    this.record = record;
+    this.svc = svc;
+  }
+
+  private T svc() {
+    return svc;
+  }
+
+  Record record() {
+    return record;
+  }
+
+  static <T> Set<RegistrationHolder<ServiceInstance<T>>> filter(
+      Set<RegistrationHolder<ServiceInstance<T>>> registrations,
+      Collection<ServiceInstance<T>> instances) {
+    List<RegistrationHolder<ServiceInstance<T>>> toRemove = new ArrayList<>();
+    for (RegistrationHolder<ServiceInstance<T>> holder : registrations) {
+      for (ServiceInstance<T> instance : instances) {
+        String id = instance.getId();
+        if (holder.svc().getId().equals(id)) {
+          toRemove.add(holder);
+        }
+      }
+    }
+    registrations.removeAll(toRemove);
+    return registrations;
+  }
+
+  static <T> Set<ServiceInstance<T>> filter(
+      Set<ServiceInstance<T>> instances,
+      Set<RegistrationHolder<ServiceInstance<T>>> registrations) {
+    List<ServiceInstance<T>> toRemove = new ArrayList<>();
+
+    for (ServiceInstance<T> instance : instances) {
+      String id = instance.getId();
+      for (RegistrationHolder<ServiceInstance<T>> holder : registrations) {
+        if (holder.svc().getId().equals(id)) {
+          toRemove.add(instance);
+        }
+      }
+    }
+
+    instances.removeAll(toRemove);
+    return instances;
+  }
+}

--- a/vertx-service-discovery-bridge-zookeeper/src/main/java/io/vertx/servicediscovery/zookeeper/ZookeeperServiceImporter.java
+++ b/vertx-service-discovery-bridge-zookeeper/src/main/java/io/vertx/servicediscovery/zookeeper/ZookeeperServiceImporter.java
@@ -1,0 +1,252 @@
+package io.vertx.servicediscovery.zookeeper;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ConcurrentHashSet;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.servicediscovery.Record;
+import io.vertx.servicediscovery.spi.ServiceImporter;
+import io.vertx.servicediscovery.spi.ServicePublisher;
+import io.vertx.servicediscovery.spi.ServiceType;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.recipes.cache.TreeCache;
+import org.apache.curator.framework.recipes.cache.TreeCacheEvent;
+import org.apache.curator.framework.recipes.cache.TreeCacheListener;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.apache.zookeeper.KeeperException;
+
+import java.util.*;
+
+/**
+ * A service importer retrieving services from Zookeeper.
+ *
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class ZookeeperServiceImporter implements ServiceImporter, TreeCacheListener {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZookeeperServiceImporter.class);
+  private ServicePublisher publisher;
+  private CuratorFramework client;
+  private ServiceDiscovery<JsonObject> discovery;
+  private TreeCache cache;
+  private volatile boolean started;
+
+  private Set<RegistrationHolder<ServiceInstance<JsonObject>>> registrations = new ConcurrentHashSet<>();
+
+  @Override
+  public void start(Vertx vertx, ServicePublisher publisher, JsonObject configuration, Future<Void> future) {
+    this.publisher = publisher;
+
+    String connection = Objects.requireNonNull(configuration.getString("connection"));
+    int maxRetries = configuration.getInteger("maxRetries", 3);
+    int baseGraceBetweenRetries = configuration.getInteger("baseSleepTimeBetweenRetries", 1000);
+    String basePath = configuration.getString("basePath", "/discovery");
+
+    vertx.<Void>executeBlocking(
+        f -> {
+          try {
+            client = CuratorFrameworkFactory.newClient(connection,
+                new ExponentialBackoffRetry(baseGraceBetweenRetries, maxRetries));
+            client.start();
+            client.blockUntilConnected();
+
+            discovery = ServiceDiscoveryBuilder.builder(JsonObject.class)
+                .client(client)
+                .basePath(basePath)
+                .serializer(new JsonObjectSerializer())
+                .watchInstances(true)
+                .build();
+
+            discovery.start();
+
+            cache = TreeCache.newBuilder(client, basePath).build();
+            cache.start();
+            cache.getListenable().addListener(this);
+
+            f.complete();
+          } catch (Exception e) {
+            future.fail(e);
+          }
+        },
+        ar -> {
+          if (ar.failed()) {
+            future.fail(ar.cause());
+          } else {
+            Future<Void> f = Future.future();
+            f.setHandler(x -> {
+              if (x.failed()) {
+                future.fail(x.cause());
+              } else {
+                started = true;
+                future.complete(null);
+              }
+            });
+            compute(f);
+          }
+        }
+    );
+  }
+
+  private synchronized void compute(Future<Void> done) {
+    List<ServiceInstance<JsonObject>> instances = new ArrayList<>();
+    try {
+      Collection<String> names = discovery.queryForNames();
+      for (String name : names) {
+        instances.addAll(discovery.queryForInstances(name));
+      }
+    } catch (KeeperException.NoNodeException e) {
+      // no services
+      // Continue
+    } catch (Exception e) {
+      if (done != null) {
+        done.fail(e);
+      } else {
+        LOGGER.error("Unable to retrieve service instances from Zookeeper", e);
+        return;
+      }
+    }
+    // Current set
+    Set<RegistrationHolder<ServiceInstance<JsonObject>>> registered
+        = new HashSet<>(registrations);
+    Set<ServiceInstance<JsonObject>> remote = new HashSet<>(instances);
+
+    List<Future> actions = new ArrayList<>();
+
+    RegistrationHolder.filter(registered, instances)
+        .stream()
+        .map(reg -> {
+          Future<Void> future = Future.future();
+          publisher.unpublish(reg.record().getRegistration(), v -> {
+            registrations.remove(reg);
+            if (v.succeeded()) {
+              future.complete(null);
+            } else {
+              future.fail(v.cause());
+            }
+          });
+          return future;
+        }).forEach(actions::add);
+
+    RegistrationHolder.filter(remote, registrations)
+        .stream()
+        .map(instance -> {
+          Future<Void> future = Future.future();
+          publisher.publish(createRecordForInstance(instance), v -> {
+            if (v.succeeded()) {
+              registrations.add(new RegistrationHolder<>(v.result(), instance));
+              future.complete(null);
+            } else {
+              future.fail(v.cause());
+            }
+          });
+          return future;
+        }).forEach(actions::add);
+
+    if (done != null) {
+      CompositeFuture.all(actions).setHandler(ar -> {
+        if (ar.succeeded()) {
+          done.complete(null);
+        } else {
+          done.fail(ar.cause());
+        }
+      });
+    }
+
+  }
+
+  static Record createRecordForInstance(ServiceInstance<JsonObject> instance) {
+    Record record = new Record();
+    record.setName(instance.getName());
+    JsonObject payload = instance.getPayload();
+    record.setMetadata(payload);
+    record.getMetadata().put("zookeeper-service-type", instance.getServiceType().toString());
+    record.getMetadata().put("zookeeper-address", instance.getAddress());
+    record.getMetadata().put("zookeeper-registration-time",
+        instance.getRegistrationTimeUTC());
+    record.getMetadata().put("zookeeper-port", instance.getPort());
+    record.getMetadata().put("zookeeper-ssl-port", instance.getSslPort());
+    record.getMetadata().put("zookeeper-id", instance.getId());
+
+    record.setLocation(new JsonObject());
+    if (instance.getUriSpec() != null) {
+      String uri = instance.buildUriSpec();
+      record.getLocation().put("endpoint", uri);
+    } else {
+      String uri = "http";
+      if (instance.getSslPort() != null) {
+        uri += "s://" + instance.getAddress() + ":" + instance.getSslPort();
+      } else if (instance.getPort() != null) {
+        uri += "s://" + instance.getAddress() + ":" + instance.getPort();
+      } else {
+        uri += "://" + instance.getAddress();
+      }
+      record.getLocation().put("endpoint", uri);
+    }
+    if (instance.getPort() != null) {
+      record.getLocation().put("port", instance.getPort());
+    }
+    if (instance.getSslPort() != null) {
+      record.getLocation().put("ssl-port", instance.getSslPort());
+    }
+    if (instance.getAddress() != null) {
+      record.getLocation().put("address", instance.getAddress());
+    }
+
+    record.setType(payload.getString("service-type", ServiceType.UNKNOWN));
+
+    return record;
+  }
+
+
+  @Override
+  public void close(Handler<Void> closeHandler) {
+    Future<Void> done = Future.future();
+    unregisterAllServices(done);
+
+    done.setHandler(v -> {
+      try {
+        cache.close();
+        discovery.close();
+        client.close();
+      } catch (Exception e) {
+        // Ignore them
+      }
+      closeHandler.handle(null);
+    });
+  }
+
+  @Override
+  public void childEvent(CuratorFramework curatorFramework,
+                         TreeCacheEvent treeCacheEvent) throws Exception {
+    if (started) {
+      compute(null);
+    }
+  }
+
+  private synchronized void unregisterAllServices(Future<Void> done) {
+    List<Future> list = new ArrayList<>();
+
+    new HashSet<>(registrations).forEach(reg -> {
+      Future<Void> unreg = Future.future();
+      publisher.unpublish(reg.record().getRegistration(), unreg.completer());
+    });
+    registrations.clear();
+
+    CompositeFuture.all(list).setHandler(x -> {
+      if (x.failed()) {
+        done.fail(x.cause());
+      } else {
+        done.complete();
+      }
+    });
+  }
+
+}

--- a/vertx-service-discovery-bridge-zookeeper/src/main/java/io/vertx/servicediscovery/zookeeper/package-info.java
+++ b/vertx-service-discovery-bridge-zookeeper/src/main/java/io/vertx/servicediscovery/zookeeper/package-info.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2011-2016 The original author or authors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+/**
+ * = Vert.x Discovery Bridge - Zookeeper
+ *
+ * This discovery bridge imports services from https://zookeeper.apache.org/[Apache Zookeeper] into the Vert.x service
+ * discovery. The bridge uses the http://curator.apache.org/curator-x-discovery/[Curator extension for service discovery].
+ *
+ * Service description are read as JSON Object (merged in the Vert.x service record metadata). The service type is
+ * deduced from this description by reading the `service-type`.
+ *
+ * == Using the bridge
+ *
+ * To use this Vert.x discovery bridge, add the following dependency to the _dependencies_ section of your build
+ * descriptor:
+ *
+ * * Maven (in your `pom.xml`):
+ *
+ * [source,xml,subs="+attributes"]
+ * ----
+ * <dependency>
+ *   <groupId>${maven.groupId}</groupId>
+ *   <artifactId>${maven.artifactId}</artifactId>
+ *   <version>${maven.version}</version>
+ * </dependency>
+ * ----
+ *
+ * * Gradle (in your `build.gradle` file):
+ *
+ * [source,groovy,subs="+attributes"]
+ * ----
+ * compile '${maven.groupId}:${maven.artifactId}:${maven.version}'
+ * ----
+ *
+ * Then, when creating the service discovery registers this bridge as follows:
+ *
+ * [source, $lang]
+ * ----
+ * {@link examples.Examples#register(io.vertx.core.Vertx)}
+ * ----
+ *
+ * Only the `connection` configuration is mandatory. It's the connection _string_ of the Zookeeper server.
+ *
+ * In addition you can configure:
+ *
+ * * `maxRetries`: the number of connection attempt, 3 by default
+ * * `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
+ * 1000 ms by default.
+ * * `basePath`: the Zookeeper path in which the service are stored. Default to `/discovery`.
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.Examples#register2(io.vertx.core.Vertx)}
+ * ----
+ *
+ */
+@ModuleGen(name = "vertx-service-discovery-zookeeper", groupPackage = "io.vertx")
+@Document(fileName = "index.adoc")
+package io.vertx.servicediscovery.zookeeper;
+
+import io.vertx.codegen.annotations.ModuleGen;
+import io.vertx.docgen.Document;

--- a/vertx-service-discovery-bridge-zookeeper/src/main/java/io/vertx/servicediscovery/zookeeper/package-info.java
+++ b/vertx-service-discovery-bridge-zookeeper/src/main/java/io/vertx/servicediscovery/zookeeper/package-info.java
@@ -61,6 +61,8 @@
  * * `baseSleepTimeBetweenRetries`: the amount of milliseconds to wait between retries (exponential backoff strategy).
  * 1000 ms by default.
  * * `basePath`: the Zookeeper path in which the service are stored. Default to `/discovery`.
+ * * `connectionTimeoutMs`: the connection timeout in milliseconds. Defaults to 1000.
+ * * `canBeReadOnly` : whether or not the backend support the _read-only_ mode (defaults to true)
  *
  * [source,$lang]
  * ----

--- a/vertx-service-discovery-bridge-zookeeper/src/test/java/io/vertx/servicediscovery/zookeeper/RecordCreationTest.java
+++ b/vertx-service-discovery-bridge-zookeeper/src/test/java/io/vertx/servicediscovery/zookeeper/RecordCreationTest.java
@@ -1,0 +1,76 @@
+package io.vertx.servicediscovery.zookeeper;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.servicediscovery.Record;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.apache.curator.x.discovery.UriSpec;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class RecordCreationTest {
+
+  @Test
+  public void testUnknownRecordCreation() throws Exception {
+    UriSpec uriSpec = new UriSpec("{scheme}://foo.com:{ssl-port}");
+    ServiceInstance<JsonObject> instance = ServiceInstance.<JsonObject>builder()
+        .name("foo-service")
+        .payload(new JsonObject().put("foo", "bar"))
+        .sslPort(42406)
+        .uriSpec(uriSpec)
+        .build();
+
+    Record record = ZookeeperServiceImporter.createRecordForInstance(instance);
+    assertThat(record.getName()).isEqualTo("foo-service");
+    assertThat(record.getType()).isEqualTo("unknown");
+    assertThat(record.getMetadata().getString("foo")).isEqualTo("bar");
+    assertThat(record.getMetadata().getString("zookeeper-id")).isNotEmpty();
+    assertThat(record.getLocation())
+        .contains(entry("endpoint", "https://foo.com:42406"))
+        .contains(entry("ssl-port", 42406));
+  }
+
+  @Test
+  public void testNoUriSpec() throws Exception {
+    ServiceInstance<JsonObject> instance = ServiceInstance.<JsonObject>builder()
+        .name("foo-service")
+        .payload(new JsonObject().put("foo", "bar"))
+        .sslPort(42406)
+        .address("localhost")
+        .build();
+
+    Record record = ZookeeperServiceImporter.createRecordForInstance(instance);
+    assertThat(record.getName()).isEqualTo("foo-service");
+    assertThat(record.getType()).isEqualTo("unknown");
+    assertThat(record.getMetadata().getString("foo")).isEqualTo("bar");
+    assertThat(record.getMetadata().getString("zookeeper-id")).isNotEmpty();
+    assertThat(record.getLocation())
+        .contains(entry("endpoint", "https://localhost:42406"))
+        .contains(entry("ssl-port", 42406));
+  }
+
+  @Test
+  public void testHttpRecordCreation() throws Exception {
+    UriSpec uriSpec = new UriSpec("{scheme}://example.com:{port}/foo");
+    ServiceInstance<JsonObject> instance = ServiceInstance.<JsonObject>builder()
+        .name("foo-service")
+        .payload(new JsonObject().put("foo", "bar").put("service-type", "http-endpoint"))
+        .port(8080)
+        .uriSpec(uriSpec)
+        .build();
+
+    Record record = ZookeeperServiceImporter.createRecordForInstance(instance);
+    assertThat(record.getName()).isEqualTo("foo-service");
+    assertThat(record.getType()).isEqualTo("http-endpoint");
+    assertThat(record.getMetadata().getString("foo")).isEqualTo("bar");
+    assertThat(record.getMetadata().getString("zookeeper-id")).isNotEmpty();
+    assertThat(record.getLocation())
+        .contains(entry("endpoint", "http://example.com:8080/foo"))
+        .contains(entry("port", 8080));
+  }
+
+}

--- a/vertx-service-discovery-bridge-zookeeper/src/test/java/io/vertx/servicediscovery/zookeeper/ZookeeperBridgeTest.java
+++ b/vertx-service-discovery-bridge-zookeeper/src/test/java/io/vertx/servicediscovery/zookeeper/ZookeeperBridgeTest.java
@@ -293,11 +293,4 @@ public class ZookeeperBridgeTest {
       }
     });
   }
-
-
-  // check address and url for HTTP services
-
-  // check address and url for unknown
-
-  // Stop ZK and restart it
 }

--- a/vertx-service-discovery-bridge-zookeeper/src/test/java/io/vertx/servicediscovery/zookeeper/ZookeeperBridgeTest.java
+++ b/vertx-service-discovery-bridge-zookeeper/src/test/java/io/vertx/servicediscovery/zookeeper/ZookeeperBridgeTest.java
@@ -1,0 +1,303 @@
+package io.vertx.servicediscovery.zookeeper;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.servicediscovery.Record;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.apache.curator.x.discovery.UriSpec;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class ZookeeperBridgeTest {
+
+
+  private TestingServer zkTestServer;
+  private CuratorFramework cli;
+  private ServiceDiscovery<String> discovery;
+  private Vertx vertx;
+  private io.vertx.servicediscovery.ServiceDiscovery sd;
+
+  @Before
+  public void startZookeeper() throws Exception {
+    zkTestServer = new TestingServer(2181);
+    cli = CuratorFrameworkFactory.newClient(zkTestServer.getConnectString(), new RetryOneTime(2000));
+    cli.start();
+
+    discovery = ServiceDiscoveryBuilder.builder(String.class)
+        .client(cli)
+        .basePath("/discovery")
+        .watchInstances(true)
+        .build();
+
+    discovery.start();
+    vertx = Vertx.vertx();
+    sd = io.vertx.servicediscovery.ServiceDiscovery.create(vertx);
+  }
+
+  @After
+  public void stopZookeeper() throws IOException {
+    discovery.close();
+    sd.close();
+    cli.close();
+    zkTestServer.stop();
+    vertx.close();
+  }
+
+  @Test
+  public void testRegistration(TestContext tc) throws Exception {
+    Async async = tc.async();
+
+    UriSpec uriSpec = new UriSpec("{scheme}://foo.com:{port}");
+    ServiceInstance<String> instance = ServiceInstance.<String>builder()
+        .name("foo-service")
+        .payload(new JsonObject().put("foo", "bar").encodePrettily())
+        .port((int) (65535 * Math.random()))
+        .uriSpec(uriSpec)
+        .build();
+
+    discovery.registerService(instance);
+    sd.registerServiceImporter(
+        new ZookeeperServiceImporter(),
+        new JsonObject().put("connection", zkTestServer.getConnectString()),
+        v -> {
+          if (v.failed()) {
+            v.cause().printStackTrace();
+          }
+          tc.assertTrue(v.succeeded());
+
+          sd.getRecords(x -> true, l -> {
+            if (l.failed()) {
+              l.cause().printStackTrace();
+            }
+            tc.assertTrue(l.succeeded());
+            tc.assertTrue(l.result().size() == 1);
+            tc.assertEquals("foo-service", l.result().get(0).getName());
+            async.complete();
+          });
+
+        });
+  }
+
+  @Test
+  public void testServiceArrival(TestContext tc) throws Exception {
+    Async async = tc.async();
+
+    UriSpec uriSpec = new UriSpec("{scheme}://foo.com:{port}");
+    ServiceInstance<String> instance = ServiceInstance.<String>builder()
+        .name("foo-service")
+        .payload(new JsonObject().put("foo", "bar").encodePrettily())
+        .port(8080)
+        .uriSpec(uriSpec)
+        .build();
+
+    sd.registerServiceImporter(
+        new ZookeeperServiceImporter(),
+        new JsonObject().put("connection", zkTestServer.getConnectString()),
+        v -> {
+          tc.assertTrue(v.succeeded());
+          sd.getRecords(x -> true, l -> {
+            tc.assertTrue(l.succeeded());
+            tc.assertTrue(l.result().size() == 0);
+
+            vertx.executeBlocking(future -> {
+              try {
+                this.discovery.registerService(instance);
+                future.complete();
+              } catch (Exception e) {
+                future.fail(e);
+              }
+            }, ar -> {
+              tc.assertTrue(ar.succeeded());
+              waitUntil(() -> serviceLookup(sd, 1), lookup -> {
+                tc.assertTrue(lookup.succeeded());
+                async.complete();
+              });
+            });
+          });
+        });
+  }
+
+  @Test
+  public void testArrivalDepartureAndComeBack(TestContext tc) throws Exception {
+    Async async = tc.async();
+
+    UriSpec uriSpec = new UriSpec("{scheme}://foo.com:{port}");
+    ServiceInstance<String> instance = ServiceInstance.<String>builder()
+        .name("foo-service")
+        .payload(new JsonObject().put("foo", "bar").encodePrettily())
+        .port(8080)
+        .uriSpec(uriSpec)
+        .build();
+
+    sd.registerServiceImporter(
+        new ZookeeperServiceImporter(),
+        new JsonObject().put("connection", zkTestServer.getConnectString()),
+        v -> {
+          tc.assertTrue(v.succeeded());
+          sd.getRecords(x -> true, l -> {
+            tc.assertTrue(l.succeeded());
+            tc.assertTrue(l.result().size() == 0);
+
+            vertx.executeBlocking(future -> {
+              try {
+                this.discovery.registerService(instance);
+                future.complete();
+              } catch (Exception e) {
+                future.fail(e);
+              }
+            }, ar -> {
+              tc.assertTrue(ar.succeeded());
+              waitUntil(() -> serviceLookup(sd, 1), lookup -> {
+                tc.assertTrue(lookup.succeeded());
+
+                // Leave
+                vertx.executeBlocking(future2 -> {
+                  try {
+                    this.discovery.unregisterService(instance);
+                    future2.complete();
+                  } catch (Exception e) {
+                    future2.fail(e);
+                  }
+                }, ar2 -> {
+                  waitUntil(() -> serviceLookup(sd, 0), lookup2 -> {
+                    tc.assertTrue(lookup2.succeeded());
+                    vertx.executeBlocking(future3 -> {
+                      try {
+                        this.discovery.registerService(instance);
+                        future3.complete();
+                      } catch (Exception e) {
+                        future3.fail(e);
+                      }
+                    }, ar3 -> {
+                      waitUntil(() -> serviceLookup(sd, 1), ar4 -> {
+                        tc.assertTrue(ar4.succeeded());
+                        async.complete();
+                      });
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+  }
+
+  private Future<List<Record>> serviceLookup(io.vertx.servicediscovery.ServiceDiscovery discovery, int expected) {
+    Future<List<Record>> future = Future.future();
+    discovery.getRecords(x -> true, list -> {
+      if (list.failed() || list.result().size() != expected) {
+        future.fail("service lookup failed");
+      } else {
+        future.complete(list.result());
+      }
+    });
+    return future;
+  }
+
+  // 1 here, import 1, second arrive, both imported
+  @Test
+  public void testServiceArrivalWithSameName(TestContext tc) throws Exception {
+    Async async = tc.async();
+
+    UriSpec uriSpec = new UriSpec("{scheme}://foo.com:{port}");
+    ServiceInstance<String> instance1 = ServiceInstance.<String>builder()
+        .name("foo-service")
+        .payload(new JsonObject().put("foo", "bar").encodePrettily())
+        .port(8080)
+        .uriSpec(uriSpec)
+        .build();
+
+    ServiceInstance<String> instance2 = ServiceInstance.<String>builder()
+        .name("foo-service")
+        .payload(new JsonObject().put("foo", "bar2").encodePrettily())
+        .port(8081)
+        .uriSpec(uriSpec)
+        .build();
+
+    discovery.registerService(instance1);
+
+
+    sd.registerServiceImporter(
+        new ZookeeperServiceImporter(),
+        new JsonObject().put("connection", zkTestServer.getConnectString()),
+        v -> {
+          tc.assertTrue(v.succeeded());
+          sd.getRecords(x -> true, l -> {
+            tc.assertTrue(l.succeeded());
+            tc.assertTrue(l.result().size() == 1);
+            tc.assertEquals(l.result().get(0).getName(), "foo-service");
+
+            vertx.executeBlocking(future -> {
+              try {
+                this.discovery.registerService(instance2);
+                future.complete();
+              } catch (Exception e) {
+                future.fail(e);
+              }
+            }, ar -> {
+              tc.assertTrue(ar.succeeded());
+              waitUntil(() -> serviceLookup(sd, 2), lookup -> {
+                tc.assertTrue(lookup.succeeded());
+                tc.assertEquals(lookup.result().get(0).getName(), "foo-service");
+                tc.assertEquals(lookup.result().get(1).getName(), "foo-service");
+                async.complete();
+              });
+            });
+          });
+        });
+  }
+
+
+  private <T> void waitUntil(Supplier<Future<T>> supplier, Handler<AsyncResult<T>> handler) {
+    AtomicInteger attempt = new AtomicInteger();
+    execute(attempt, supplier, handler);
+  }
+
+  private <T> void execute(AtomicInteger counter, Supplier<Future<T>> supplier,
+                           Handler<AsyncResult<T>> handler) {
+
+    supplier.get().setHandler(ar -> {
+      if (ar.succeeded()) {
+        handler.handle(Future.succeededFuture(ar.result()));
+      } else {
+        if (counter.incrementAndGet() > 10) {
+          handler.handle(Future.failedFuture("max attempt reached"));
+        } else {
+          vertx.setTimer(100, l -> {
+            execute(counter, supplier, handler);
+          });
+        }
+      }
+    });
+  }
+
+
+  // check address and url for HTTP services
+
+  // check address and url for unknown
+
+  // Stop ZK and restart it
+}

--- a/vertx-service-discovery/src/test/java/io/vertx/servicediscovery/spi/ServiceDiscoveryBackendTest.java
+++ b/vertx-service-discovery/src/test/java/io/vertx/servicediscovery/spi/ServiceDiscoveryBackendTest.java
@@ -1,0 +1,198 @@
+package io.vertx.servicediscovery.spi;
+
+import io.vertx.core.Vertx;
+import io.vertx.servicediscovery.Record;
+import io.vertx.servicediscovery.Status;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+
+/**
+ * Test to be implemented by backend implementation
+ *
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public abstract class ServiceDiscoveryBackendTest {
+
+  protected ServiceDiscoveryBackend backend;
+  protected Vertx vertx;
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+    backend = createBackend();
+  }
+
+  protected abstract ServiceDiscoveryBackend createBackend();
+
+  @After
+  public void tearDown() {
+    AtomicBoolean completed = new AtomicBoolean();
+    vertx.close(ar -> completed.set(ar.succeeded()));
+    await().untilAtomic(completed, is(true));
+  }
+
+  @Test
+  public void testInsertion() {
+    Record record = new Record().setName("my-service").setStatus(Status.UP);
+    assertThat(record.getRegistration()).isNull();
+
+    // Insertion
+    AtomicReference<Record> reference = new AtomicReference<>();
+    backend.store(record, ar -> {
+      if (!ar.succeeded()) {
+        ar.cause().printStackTrace();
+      }
+      reference.set(ar.result());
+    });
+
+    await().until(() -> reference.get() != null);
+    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
+    assertThat(reference.get().getRegistration()).isNotNull();
+    record = reference.get();
+
+    // Retrieve
+    reference.set(null);
+    backend.getRecord(record.getRegistration(), ar -> reference.set(ar.result()));
+    await().until(() -> reference.get() != null);
+    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
+    assertThat(reference.get().getRegistration()).isNotNull();
+
+    // Remove
+    AtomicBoolean completed = new AtomicBoolean();
+    backend.remove(record, ar -> {
+      completed.set(ar.succeeded());
+    });
+    await().untilAtomic(completed, is(true));
+
+    // Retrieve
+    completed.set(false);
+    reference.set(null);
+    backend.getRecord(record.getRegistration(), ar -> {
+      if (!ar.succeeded()) {
+        ar.cause().printStackTrace();
+      }
+      completed.set(ar.succeeded());
+      reference.set(ar.result());
+    });
+
+    await().untilAtomic(completed, is(true));
+    assertThat(reference.get()).isNull();
+  }
+
+  @Test
+  public void testInsertionOfMultipleRecords() {
+    Record record1 = new Record().setName("my-service-1").setStatus(Status.UP);
+    assertThat(record1.getRegistration()).isNull();
+    Record record2 = new Record().setName("my-service-2").setStatus(Status.UP);
+    assertThat(record2.getRegistration()).isNull();
+    Record record3 = new Record().setName("my-service-3").setStatus(Status.UP);
+    assertThat(record3.getRegistration()).isNull();
+
+    // Insertion
+    AtomicBoolean completed = new AtomicBoolean();
+    backend.store(record1, ar -> {
+          backend.store(record2, ar2 -> {
+            backend.store(record3, ar3 -> {
+              completed.set(ar3.succeeded());
+            });
+          });
+        }
+    );
+
+    await().untilAtomic(completed, is(true));
+
+    List<Record> records = new ArrayList<>();
+    // Get records
+    backend.getRecords(ar -> {
+      records.addAll(ar.result());
+    });
+    await().until(() -> !records.isEmpty());
+
+    assertThat(records).hasSize(3);
+
+    // Get each records
+    for (Record record : records) {
+      AtomicReference<Record> retrieved = new AtomicReference<>();
+      backend.getRecord(record.getRegistration(), ar -> retrieved.set(ar.result()));
+      await().untilAtomic(retrieved, not(nullValue()));
+    }
+  }
+
+  @Test
+  public void testInsertionFollowedByAnUpdate() {
+    Record record = new Record().setName("my-service").setStatus(Status.UP);
+    assertThat(record.getRegistration()).isNull();
+
+    // Insertion
+    AtomicReference<Record> reference = new AtomicReference<>();
+    backend.store(record, ar -> {
+      if (!ar.succeeded()) {
+        ar.cause().printStackTrace();
+      }
+      reference.set(ar.result());
+    });
+
+    await().until(() -> reference.get() != null);
+    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
+    assertThat(reference.get().getRegistration()).isNotNull();
+    record = reference.get();
+
+    // Retrieve
+    reference.set(null);
+    backend.getRecord(record.getRegistration(), ar -> reference.set(ar.result()));
+    await().until(() -> reference.get() != null);
+    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
+    assertThat(reference.get().getRegistration()).isNotNull();
+
+    // Update
+    AtomicBoolean completed = new AtomicBoolean();
+    record.getMetadata().put("some-new-key", "some-new-value");
+    backend.update(record, ar -> {
+      completed.set(ar.succeeded());
+    });
+    await().untilAtomic(completed, is(true));
+
+    // Retrieve
+    reference.set(null);
+    backend.getRecord(record.getRegistration(), ar -> reference.set(ar.result()));
+    await().until(() -> reference.get() != null);
+    assertThat(reference.get().getName()).isEqualToIgnoringCase("my-service");
+    assertThat(reference.get().getMetadata().getString("some-new-key"))
+        .isEqualToIgnoringCase("some-new-value");
+    assertThat(reference.get().getRegistration()).isNotNull();
+
+    // Remove
+    completed.set(false);
+    backend.remove(record, ar -> {
+      completed.set(ar.succeeded());
+    });
+    await().untilAtomic(completed, is(true));
+
+    // Retrieve
+    completed.set(false);
+    reference.set(null);
+    backend.getRecord(record.getRegistration(), ar -> {
+      if (!ar.succeeded()) {
+        ar.cause().printStackTrace();
+      }
+      completed.set(ar.succeeded());
+      reference.set(ar.result());
+    });
+
+    await().untilAtomic(completed, is(true));
+    assertThat(reference.get()).isNull();
+  }
+
+}


### PR DESCRIPTION
This PR provides 2 new components:

* Zookeeper Service Importer (Based on Apache Curator Service Discovery) imports services from Zookeeper using http://curator.apache.org/curator-x-discovery/
* Zookeeper service backend  stores service records in Zookeeper instead of a distributed map