### PR TITLE
Fix file name for custom service types in docs.

### DIFF
--- a/vertx-service-discovery/src/main/asciidoc/java/index.adoc
+++ b/vertx-service-discovery/src/main/asciidoc/java/index.adoc
@@ -403,7 +403,7 @@ the class with the type of service object your are going to return. You must imp
 `AbstractServiceReference#retrieve()` that creates the service object. This
 method is only called once. If your service object needs cleanup, also override
 `AbstractServiceReference#close()`.
-4. Create a `META-INF/services/io.vertx.ext.discovery.spi.ServiceType` file that is packaged in your jar. In this
+4. Create a `META-INF/services/io.vertx.servicediscovery.spi.ServiceType` file that is packaged in your jar. In this
 file, just indicate the fully qualified name of the class created at step 2.
 5. Creates a jar containing the service type interface (step 1), the implementation (step 2 and 3) and the
 service descriptor file (step 4). Put this jar in the classpath of your application. Here you go, your service

--- a/vertx-service-discovery/src/main/java/io/vertx/servicediscovery/package-info.java
+++ b/vertx-service-discovery/src/main/java/io/vertx/servicediscovery/package-info.java
@@ -292,7 +292,7 @@
  * `AbstractServiceReference#retrieve()` that creates the service object. This
  * method is only called once. If your service object needs cleanup, also override
  * `AbstractServiceReference#close()`.
- * 4. Create a `META-INF/services/io.vertx.ext.discovery.spi.ServiceType` file that is packaged in your jar. In this
+ * 4. Create a `META-INF/services/io.vertx.servicediscovery.spi.ServiceType` file that is packaged in your jar. In this
  * file, just indicate the fully qualified name of the class created at step 2.
  * 5. Creates a jar containing the service type interface (step 1), the implementation (step 2 and 3) and the
  * service descriptor file (step 4). Put this jar in the classpath of your application. Here you go, your service

--- a/vertx-service-discovery/src/main/java/io/vertx/servicediscovery/spi/ServiceType.java
+++ b/vertx-service-discovery/src/main/java/io/vertx/servicediscovery/spi/ServiceType.java
@@ -31,7 +31,7 @@ import io.vertx.servicediscovery.ServiceReference;
  * the message.
  * <p>
  * You can define your own service type by implementing this interface and configure the SPI file
- * (META-INF/services/io.vertx.ext.discovery.spi.ServiceType) with your own implementation.
+ * (META-INF/services/io.vertx.servicediscovery.spi.ServiceType) with your own implementation.
  *
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
  */


### PR DESCRIPTION
The documentation for creating a custom service type specifies to create a file under META-INF/services/ with your custom service types in it. The file name currently in the docs, `io.vertx.ext.discovery.spi.ServiceType`, didn't work for me. I had to use `io.vertx.servicediscovery.spi.ServiceType` instead. This PR updates the docs to reflect the correct file name.

Signed-off-by: Dan O'Reilly oreilldf@gmail.com
