### PR TITLE
Fix AsyncMap#getAll to get it work with vertx-infinispan

### DIFF
--- a/vertx-service-discovery/src/main/java/io/vertx/servicediscovery/impl/AsyncMap.java
+++ b/vertx-service-discovery/src/main/java/io/vertx/servicediscovery/impl/AsyncMap.java
@@ -56,12 +56,8 @@ public class AsyncMap<K, V> {
   }
 
   public void getAll(Handler<AsyncResult<Map<K, V>>> asyncResultHandler) {
-    vertx.<Map<K, V>>executeBlocking(
-        future -> {
-          Map<K, V> map = new LinkedHashMap<>();
-          syncMap.entrySet().stream().forEach(entry -> map.put(entry.getKey(), entry.getValue()));
-          future.complete(map);
-        },
+    vertx.executeBlocking(
+        future -> future.complete(new LinkedHashMap<>(syncMap)),
         asyncResultHandler
     );
   }


### PR DESCRIPTION
Infinispan distributes operations on streams so instead any lambda is expected to be serializable.

Here it's not really necessary because we only want to copy all values so a copy constructor call is enough.

See vert-x3/vertx-infinispan#35