### PR TITLE
Add support to Kubernetes external service discovery

### DIFF
--- a/vertx-service-discovery-bridge-kubernetes/src/main/java/io/vertx/servicediscovery/kubernetes/KubernetesServiceImporter.java
+++ b/vertx-service-discovery-bridge-kubernetes/src/main/java/io/vertx/servicediscovery/kubernetes/KubernetesServiceImporter.java
@@ -465,7 +465,7 @@ public class KubernetesServiceImporter implements ServiceImporter {
   }
 
   private static boolean isTrue(String ssl) {
-    return ssl != null && "true" .equalsIgnoreCase(ssl);
+    return "true".equalsIgnoreCase(ssl);
   }
 
 


### PR DESCRIPTION
This PR is intended to add support to Kubernetes external service discovery (Service type: `ExternalName`). 

More info: https://kubernetes.io/docs/concepts/services-networking/service/#externalname