### PR TITLE
backend-consul bug fix

### DIFF
--- a/vertx-service-discovery-backend-consul/src/main/java/io/vertx/servicediscovery/backend/consul/ConsulBackendService.java
+++ b/vertx-service-discovery-backend-consul/src/main/java/io/vertx/servicediscovery/backend/consul/ConsulBackendService.java
@@ -184,7 +184,9 @@ public class ConsulBackendService implements ServiceDiscoveryBackend {
     //use the checks to set the record status
     Future<CheckList> checkListFuture = Future.future();
     client.healthChecks(service.getName(), checkListFuture);
-    return checkListFuture.map(cl -> cl.getList().stream().map(Check::getStatus).allMatch(CheckStatus.PASSING::equals))
+    return checkListFuture.map(cl -> cl.getList().stream()
+      .filter(check -> check.getId().equals(service.getId()))
+      .map(Check::getStatus).allMatch(CheckStatus.PASSING::equals))
       .map(st -> st ? new Record().setStatus(Status.UP) : new Record().setStatus(Status.DOWN))
       .map(record -> {
         record.setMetadata(new JsonObject());

--- a/vertx-service-discovery-backend-consul/src/main/java/io/vertx/servicediscovery/backend/consul/ConsulBackendService.java
+++ b/vertx-service-discovery-backend-consul/src/main/java/io/vertx/servicediscovery/backend/consul/ConsulBackendService.java
@@ -110,9 +110,13 @@ public class ConsulBackendService implements ServiceDiscoveryBackend {
         l.forEach(s -> {
           if (!"consul".equals(s.getName())) {
             ServiceQueryOptions opt = new ServiceQueryOptions();
-            if (!s.getTags().isEmpty()) {
-              opt.setTag(s.getTags().get(0));
+            List<String> tags = s.getTags().stream()
+              .filter(tag -> !tag.equals("http-endpoint") && !tag.contains("metadata:") && !tag.contains("location:"))
+              .collect(Collectors.toList());
+            if (!tags.isEmpty()) {
+              opt.setTag(tags.get(0));
             }
+
             Future<ServiceList> serviceList = Future.future();
             client.catalogServiceNodesWithOptions(s.getName(), opt, serviceList);
             recordFutureList.add(serviceList);


### PR DESCRIPTION
the bug happened when using `docker-compose scale `
the method `getRecords` will get all `DOWN` status Record when there is only a few instances `DOWN`. add a filter to pattern same serviceId CheckList to avoid 

the second commit is in same situation,  when a instance down and the tag is `location:{down-instacen.ip,xxxx}`   ,so records  are only one ip records. even all instances arre up, when the tag is `location:` ,also can not find all records .