### PR TITLE
Updated Zookeeper version

### DIFF
--- a/vertx-service-discovery-backend-zookeeper/pom.xml
+++ b/vertx-service-discovery-backend-zookeeper/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.10</version>
+      <version>3.4.13</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/vertx-service-discovery-bridge-zookeeper/pom.xml
+++ b/vertx-service-discovery-bridge-zookeeper/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.10</version>
+      <version>3.4.13</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Upgrading the vertx-kafka-client to use newer version of the native Kafka client (2.1.0) will take a conflict on Zookeeper dependency with this component.
This upgrade is needed for fixing the conflict.