### PR TITLE
Updated Zookeeper version

### DIFF
--- a/vertx-service-discovery-backend-zookeeper/pom.xml
+++ b/vertx-service-discovery-backend-zookeeper/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.13</version>
+      <version>3.4.14</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/vertx-service-discovery-bridge-zookeeper/pom.xml
+++ b/vertx-service-discovery-bridge-zookeeper/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.13</version>
+      <version>3.4.14</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This PR is related to bumping the Kafka version to 2.3.0 in the Vert.x Kafka client.