### PR TITLE
Replace createNonShared with create

### DIFF
--- a/vertx-service-discovery/src/main/java/io/vertx/servicediscovery/types/impl/MongoDataSourceImpl.java
+++ b/vertx-service-discovery/src/main/java/io/vertx/servicediscovery/types/impl/MongoDataSourceImpl.java
@@ -56,7 +56,7 @@ public class MongoDataSourceImpl implements MongoDataSource {
       if (result.getBoolean("shared", false)) {
         return MongoClient.createShared(vertx, result);
       } else {
-        return MongoClient.createNonShared(vertx, result);
+        return MongoClient.create(vertx, result);
       }
     }
 


### PR DESCRIPTION
createNonShared(Vertx vertx, JsonObject config) was deprecated and then removed from vertx-mongo-client

https://github.com/vert-x3/vertx-mongo-client/commit/4500f715eabb4667ead0a73553645af89ab05b1e