### PR TITLE
Bump version and exclude javax.annotation to satisfy vertx-stack

### DIFF
--- a/vertx-service-discovery-bridge-docker/pom.xml
+++ b/vertx-service-discovery-bridge-docker/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>com.github.docker-java</groupId>
       <artifactId>docker-java</artifactId>
-      <version>3.0.0</version>
+      <version>3.1.5</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -122,6 +122,10 @@
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
`javax.annotation:javax.annotation-api:jar:1.2` is in conflict with `javax.annotation:javax.annotation-api:jar:1.3.1` other dependencies bring. 