### PR TITLE
vertx-service-discovery-bridge-docker uses a different version of jackson

### DIFF
--- a/vertx-service-discovery-bridge-docker/pom.xml
+++ b/vertx-service-discovery-bridge-docker/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <doc.skip>true</doc.skip>
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.11.3</jackson.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Changed jackson version to match one defined in vertx-dependencies