### PR TITLE
chore(kubernetes): log bearer token on debug level

### DIFF
--- a/vertx-service-discovery-bridge-kubernetes/src/main/java/io/vertx/servicediscovery/kubernetes/KubernetesServiceImporter.java
+++ b/vertx-service-discovery-bridge-kubernetes/src/main/java/io/vertx/servicediscovery/kubernetes/KubernetesServiceImporter.java
@@ -117,7 +117,7 @@ public class KubernetesServiceImporter implements ServiceImporter {
 
     retrieveTokenFuture
       .map(t -> {
-        LOGGER.info("Kubernetes discovery: Bearer Token { " + t + " }");
+        LOGGER.debug("Kubernetes discovery: Bearer Token { " + t + " }");
         return t;
       })
       .compose(this::retrieveServices)


### PR DESCRIPTION
Motivation:

#147 

**NOTE:** I am making this change from the web-UI and am assuming it's correct, but it's entirely possible that `LOGGER.debug` doesn't exist. :)