### PR TITLE
KubernetesServiceImporter: reconnect if watch gets closed

### DIFF
--- a/vertx-service-discovery-bridge-kubernetes/src/test/java/io/vertx/servicediscovery/kubernetes/KubernetesServerTest.java
+++ b/vertx-service-discovery-bridge-kubernetes/src/test/java/io/vertx/servicediscovery/kubernetes/KubernetesServerTest.java
@@ -52,7 +52,7 @@ public class KubernetesServerTest {
     server.expect().get().withPath("/api/v1/namespaces/default/services").andReturn(200, new ServiceListBuilder()
       .addToItems(svc1, svc2).withNewMetadata("1234", "/self").build()).always();
 
-    server.expect().get().withPath("/api/v1/namespaces/default/services?watch=true&resourceVersion=1234")
+    server.expect().get().withPath("/api/v1/namespaces/default/services?watch=true&allowWatchBookmarks=true&resourceVersion=1234")
       .andReturnChunked(200,
         new WatchEvent(svc3, "ADDED"), "\n",
         new WatchEvent(svc1, "DELETED"), "\n",
@@ -62,7 +62,7 @@ public class KubernetesServerTest {
     server.expect().get().withPath("/api/v1/namespaces/issue96/services").andReturn(200, new ServiceListBuilder()
       .addToItems(svc96)
       .withNewMetadata("1235", "/self").build()).always();
-    server.expect().get().withPath("/api/v1/namespaces/issue96/services?watch=true&resourceVersion=1235")
+    server.expect().get().withPath("/api/v1/namespaces/issue96/services?watch=true&allowWatchBookmarks=true&resourceVersion=1235")
       .andReturnChunked(200,
         new WatchEvent(getUpdatedService96(), "MODIFIED"), "\n",
         new WatchEvent(getUpdatedService96(), "DELETED"), "\n").once();


### PR DESCRIPTION
Fixes #113

- removed synchronization on fields; instead, execute importer on context
- replaced WebClient with HttpClient: it is better suited for JSON stream parsing
- use k8s bookmarks if available: avoids re-fetching all history if watch is closed by the server (poll timeout)
- change records list to map: avoids traversing the list over and over again when processing k8s api response
- watch for last known resource version when watch poll request is closed by server
- retrieve and watch again when watch fails for any other reason